### PR TITLE
fix: 초기세팅 수정에 따른 Agent.md 및 README.md 수정

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -25,8 +25,13 @@ src/
 │   │   │   └── layout.tsx
 │   │   └── mover/        # 기사님 회원가입/로그인 (URL: /mover/...)
 │   │       └── layout.tsx
-│   ├── (main)/           # 메인 서비스 라우트 그룹
+│   ├── (main)/           # 메인 서비스 라우트 그룹 (공개 페이지, 로그인 불필요)
 │   │   └── page.tsx      # 루트("/") 랜딩 페이지
+│   ├── (protected)/      # 로그인 필요한 페이지, role별 분기
+│   │   ├── customer/     # 일반 유저 전용 (마이페이지 등, URL: /customer/...)
+│   │   │   └── layout.tsx
+│   │   └── mover/        # 기사님 전용 (대시보드 등, URL: /mover/...)
+│   │       └── layout.tsx
 │   ├── layout.tsx        # 루트 레이아웃
 │   ├── providers.tsx     # Provider 조립 (QueryProvider 등), RootLayout에서 사용
 │   ├── not-found.tsx
@@ -47,6 +52,7 @@ src/
 ```
 
 - `customer` / `mover`는 (같은 `/login` 등 페이지명이 겹쳐서) URL 충돌 방지 위해 일반 폴더로 분리 — `/customer/...`, `/mover/...`. 각자 `layout.tsx`에서 공통 UI/가드 처리
+- `(auth)/customer`·`(protected)/customer` (mover도 동일)처럼 같은 이름 폴더가 서로 다른 그룹에 있을 수 있음 — 그룹은 URL에 안 보이니 두 그룹에 걸쳐 같은 하위 경로(예: 양쪽에 `page.tsx` 루트)를 만들면 URL 충돌남. `(auth)`는 로그인/회원가입, `(protected)`는 로그인 후 페이지로 하위 경로 안 겹치게 유지
 - 절대경로 import는 `@/*` → `src/*` 로 매핑되어 있음 (`tsconfig.json`)
   - 예: `import { X } from "@/app/..."`
 - `types/`, `constants/`는 필요해지는 시점에 추가 (현재는 미생성)

--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@
 
 ## 🛠 기술 스택
 
-| 구분             | 기술                      |
-| ---------------- | ------------------------- |
-| **Framework**    | Next.js 16 (App Router)   |
-| **Language**     | TypeScript 6              |
-| **UI**           | React 19 · Tailwind CSS 4 |
-| **State / Data** | TanStack Query 5          |
-| **Form**         | React Hook Form 7         |
-| **Lint**         | ESLint 9                  |
+| 구분              | 기술                             |
+| ----------------- | -------------------------------- |
+| **Framework**     | Next.js 16 (App Router)          |
+| **Language**      | TypeScript 6                     |
+| **UI**            | React 19 · Tailwind CSS 4        |
+| **State / Data**  | TanStack Query 5                 |
+| **Form**          | React Hook Form 7                |
+| **Lint / Format** | ESLint 9 · Prettier 3            |
+| **Git Hooks**     | husky · lint-staged · commitlint |
 
 <br />
 
@@ -94,22 +95,39 @@ npm run lint     # 린트 검사
 
 ## 📁 프로젝트 구조
 
-```
+```text
 src/
-└── app/              # App Router
-    ├── layout.tsx
-    ├── page.tsx
-    └── globals.css
+├── app/
+│   ├── (main)/           # 공개 페이지, 로그인 불필요
+│   │   └── page.tsx      # 루트("/") 랜딩 페이지
+│   ├── (auth)/           # 로그인/회원가입 플로우
+│   │   ├── customer/     # 일반 유저 (URL: /customer/...)
+│   │   └── mover/        # 기사님 (URL: /mover/...)
+│   ├── (protected)/      # 로그인 필요, role별 분기
+│   │   ├── customer/     # 일반 유저 전용
+│   │   └── mover/        # 기사님 전용
+│   ├── layout.tsx        # 루트 레이아웃
+│   ├── providers.tsx     # Provider 조립
+│   ├── not-found.tsx
+│   ├── loading.tsx
+│   └── globals.css       # 디자인 토큰 · 폰트 · 반응형 브레이크포인트
+├── assets/               # fonts · icons · images
+├── components/           # 공통 컴포넌트
+├── hooks/                # 커스텀 훅
+├── lib/                  # actions · services · utils
+└── providers/            # QueryProvider 등 개별 provider 구현체
 ```
+
+세부 구조·컨벤션은 `AGENT.md` 참고.
 
 <br />
 
 ## 🌿 브랜치 전략
 
-```
+```text
 main        운영 배포
  └── dev    개발 통합 (기본 브랜치)
-      └── feat-기능이름-이슈번호
+      └── {type}/{작업명}-{이슈번호}   예: feat/mover-list-page-18
 ```
 
 - 이슈 생성 시 브랜치를 함께 생성합니다

--- a/src/app/(protected)/customer/layout.tsx
+++ b/src/app/(protected)/customer/layout.tsx
@@ -1,0 +1,6 @@
+import { type PropsWithChildren } from "react";
+
+export default function CustomerProtectedLayout({ children }: PropsWithChildren) {
+  // TODO: 세션 체크 + role !== "customer"면 리다이렉트 (인증 로직 구현 후 추가)
+  return <div>{children}</div>;
+}

--- a/src/app/(protected)/mover/layout.tsx
+++ b/src/app/(protected)/mover/layout.tsx
@@ -1,0 +1,6 @@
+import { type PropsWithChildren } from "react";
+
+export default function MoverProtectedLayout({ children }: PropsWithChildren) {
+  // TODO: 세션 체크 + role !== "mover"면 리다이렉트 (인증 로직 구현 후 추가)
+  return <div>{children}</div>;
+}


### PR DESCRIPTION
## 📌 개요

- `(protected)` 라우트 그룹(customer/mover, role별 로그인 필요 페이지) 스캐폴딩 추가 및 `AGENT.md`/`README.md`를 실제 프로젝트 구조에 맞게 동기화

## 🔢 Linked Issue

- close #13 

## 🛠️ 주요 변경 사항

- [x] `(protected)/customer`, `(protected)/mover` layout 추가 — 로그인 필요 페이지용 라우트 그룹, role 가드는 인증 로직 구현 시 TODO 자리에 추가 예정
- [x] `AGENT.md`, `README.md` 프로젝트 구조 트리를 실제 폴더 구조(`(main)`/`(auth)`/`(protected)`, assets/components/hooks/lib/providers)에 맞게 갱신, 브랜치 네이밍 표기 오타(`feat-이름-번호` → `{type}/{작업명}-{이슈번호}`) 수정

## 📸 스크린샷 (선택)

- 해당 없음 (문서·라우트 스캐폴딩만 변경, UI 변경 없음)

## 🧪 테스트 결과 & 리뷰 요청 사항

- `npm run lint`, `npm run build` 통과 확인
- 리뷰 요청: `(auth)`와 `(protected)`에 동시에 `customer`/`mover` 폴더가 있는 구조라 향후 두 그룹에 같은 하위 경로(`page.tsx` 등) 안 겹치게 주의 필요 — 이 부분 네이밍/구조 괜찮은지 의견 부탁

## 📋 완료 체크리스트

- [x] 브랜치 방향(To dev)을 올바르게 설정했나요?
- [x] 무관한 파일이나 테스트용 코드가 커밋에 포함되지 않았나요?
- [x] (`npm run dev`) 시 에러가 발생하지 않나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
  - 앱 라우팅 구조와 공개 페이지, 인증 보호 영역, 고객·기사별 페이지 구분을 상세히 정리했습니다.
  - 인증 및 보호 라우트 간 경로 충돌 가능성에 대한 안내를 추가했습니다.
  - 기술 스택, 코드 품질 도구, 프로젝트 구조 및 브랜치 명명 규칙 문서를 업데이트했습니다.

- **개선**
  - 고객 및 기사 전용 영역에서 콘텐츠를 일관되게 표시할 수 있는 보호 레이아웃을 추가했습니다.
  - 역할 확인 및 접근 제한 기능은 추후 지원될 예정입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->