### PR TITLE
fix: 초기세팅 컨벤션 정리에 따른 타이포그래피·children 타입 수정 및 문서 반영

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,5 +5,6 @@
   "tabWidth": 2,
   "trailingComma": "es5",
   "arrowParens": "always",
-  "endOfLine": "lf"
+  "endOfLine": "lf",
+  "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/AGENT.md
+++ b/AGENT.md
@@ -13,7 +13,18 @@ Cursor/AI 에이전트가 이 저장소에서 작업할 때 참고하는 규칙 
 - Tailwind CSS 4
 - TanStack Query 5 (서버 상태)
 - React Hook Form 7 (폼)
-- ESLint 9 (eslint-config-next 기반) · Prettier 3 (포맷) · husky + lint-staged + commitlint (커밋 전 자동 검사)
+- ESLint 9 (eslint-config-next 기반) · Prettier 3 + prettier-plugin-tailwindcss (포맷, 클래스 자동 정렬) · husky + lint-staged + commitlint (커밋 전 자동 검사)
+
+## 버전 관리
+
+| 항목       | 버전 |
+| ---------- | ---- |
+| TypeScript | 6.x  |
+| Next.js    | 16.x |
+| React      | 19.x |
+
+- 패키지 추가 시 팀에 공유
+- 메이저 버전 업그레이드는 회의에서 결정
 
 ## 프로젝트 구조
 
@@ -41,7 +52,7 @@ src/
 │   ├── fonts/            # PretendardVariable.ttf (next/font/local)
 │   ├── icons/            # SVG 아이콘
 │   └── images/           # common/, landing/ 등 목적별 하위 폴더
-├── components/
+├── component/
 │   └── common/           # 공통 컴포넌트
 ├── hooks/                # 커스텀 훅
 ├── lib/
@@ -57,20 +68,82 @@ src/
   - 예: `import { X } from "@/app/..."`
 - `types/`, `constants/`는 필요해지는 시점에 추가 (현재는 미생성)
 
+## 네이밍 컨벤션
+
+### 공통
+
+| 대상              | 케이스                        | 예시                                |
+| ----------------- | ----------------------------- | ----------------------------------- |
+| 변수              | camelCase                     | `moverProfile`, `isTargeted`        |
+| 상수              | UPPER_SNAKE_CASE              | `MAX_ESTIMATE_COUNT`, `ERROR_CODES` |
+| 함수              | camelCase                     | `createNotification`, `findByEmail` |
+| 타입 · 인터페이스 | PascalCase                    | `AuthResult`, `CreateEstimateDto`   |
+| Enum              | PascalCase (값은 UPPER_SNAKE) | `UserRole.CUSTOMER`                 |
+
+### 함수 이름 접두어
+
+| 접두어       | 용도               | 예시                       |
+| ------------ | ------------------ | -------------------------- |
+| `get`        | 조회 (없으면 에러) | `getUserById`              |
+| `find`       | 조회 (없으면 null) | `findByEmailAndRole`       |
+| `create`     | 생성               | `createQuotationRequest`   |
+| `update`     | 수정               | `updateMoverProfile`       |
+| `delete`     | 삭제               | `deleteFavorite`           |
+| `is` / `has` | boolean 반환       | `isTargeted`, `hasProfile` |
+
+### 파일 · 폴더
+
+> 파일명은 전부 kebab-case로 통일 (컴포넌트도 포함). Next.js가 이름을 강제하는 특수 파일(`page.tsx`, `layout.tsx`, `loading.tsx`, `not-found.tsx` 등)만 예외. `check-file` ESLint 룰로 강제됨 (자동수정 안 됨, 직접 이름 변경 필요)
+
+| 대상          | 케이스                     | 예시                     |
+| ------------- | -------------------------- | ------------------------ |
+| 컴포넌트 파일 | kebab-case                 | `mover-card.tsx`         |
+| 훅 파일       | kebab-case (`use-` 접두어) | `use-mover-list.ts`      |
+| 유틸 파일     | kebab-case                 | `format-date.ts`         |
+| 라우트 폴더   | kebab-case                 | `app/quotation-request/` |
+| 일반 폴더     | kebab-case                 | `component/`, `hooks/`   |
+
+### API 엔드포인트 (참고: BE가 정의, FE는 이 규칙대로 호출)
+
+| 규칙               | 예시                                   |
+| ------------------ | -------------------------------------- |
+| kebab-case 복수형  | `/api/quotation-requests`              |
+| 하위 리소스는 중첩 | `/api/quotation-requests/{id}/targets` |
+| 동작은 동사        | `/api/estimates/{id}/confirm`          |
+
 ## 코딩 규칙
 
 - 컴포넌트는 함수형 + TypeScript로 작성, `strict` 모드 위반 없도록 타입 명시
+- `any` 사용 금지 (불가피하면 `unknown` + 타입 가드)
+- 주석은 **왜**를 설명 (무엇을 하는지는 코드로)
 - 클라이언트 컴포넌트가 필요할 때만 최상단에 `"use client"` 명시 (기본은 서버 컴포넌트)
 - 서버 상태(API 데이터)는 TanStack Query로, 폼 상태는 React Hook Form으로 관리 — `useState`로 중복 관리하지 않음
 - 클래스명 조합은 `clsx` 사용
-- children만 받는 컴포넌트는 직접 타입 정의 대신 React `PropsWithChildren` 사용
+- children만 받는 컴포넌트는 `{ children: ReactNode }`로 직접 타입 정의 — `PropsWithChildren`은 `children`을 옵셔널로 만들어서 안티패턴, 사용 금지
+- 타입 정의: 컴포넌트 Props·객체 모양(shape)은 `interface`, Union·Intersection·함수 타입·primitive alias는 `type` 사용
+- 타입 위치: 여러 곳에서 쓰는 공용 타입은 `src/types/`, 컴포넌트 전용 Props 타입은 해당 컴포넌트 파일에 로컬로 정의
 - 새 provider(예: `AuthProvider`, `ModalProvider`)는 `src/providers/`에 구현체 먼저 만들고, `src/app/providers.tsx`에서 import해서 조립 (RootLayout이 직접 여러 provider를 감싸지 않도록)
-- 파일명은 kebab-case (예: `query-provider.tsx`) — Next.js가 이름을 강제하는 특수 파일(`page.tsx`, `layout.tsx`, `loading.tsx`, `not-found.tsx` 등)은 예외. `check-file` ESLint 룰로 강제됨 (자동수정 안 됨, 직접 이름 변경 필요)
 - import는 `@/` 절대경로 사용, 상위 폴더 상대경로(`../`) 금지 (ESLint `no-restricted-imports`로 강제됨) — 같은 폴더 내 `./`는 허용
 - 안 쓰는 import는 `eslint --fix` 시 자동 삭제됨 (`eslint-plugin-unused-imports`), 안 쓰는 변수는 `_` 접두어로 무시 처리
 - 빈 줄 2개 이상 연속 금지 (`no-multiple-empty-lines`, `--fix` 시 1개로 자동 압축)
 - 코드 포맷(따옴표·들여쓰기·줄바꿈)은 Prettier(`.prettierrc.json`)가 담당 — ESLint 룰과 역할 안 겹침
 - 새 코드 작성 후 `npm run lint` 통과 확인. 어차피 `git commit` 시 lint-staged가 스테이징된 파일에 자동으로 `eslint --fix` + `prettier --write`를 돌리지만, `no-restricted-imports`·`check-file` 위반은 자동수정 안 되고 커밋이 막히니 미리 확인할 것
+
+## API 응답 형식 (참고: BE 응답 계약, FE 타입 정의 시 기준)
+
+```json
+// 성공
+{ "data": { ... } }
+
+// 목록 (커서)
+{ "data": [...], "nextCursor": "...", "hasNext": true }
+
+// 목록 (페이지)
+{ "data": [...], "page": 1, "totalPages": 5, "totalCount": 47 }
+
+// 실패
+{ "error": { "code": "ACTIVE_REQUEST_EXISTS", "message": "..." } }
+```
 
 ## 커밋 컨벤션
 
@@ -84,7 +157,18 @@ commitlint로 강제됨 (`commitlint.config.js`), 아래 타입만 허용:
 | `test`     | 테스트 코드      |
 | `refactor` | 코드 리팩토링    |
 
-형식: `type: subject` (husky pre-commit/commit-msg 훅으로 검증됨)
+형식: `{type}: {내용}` (husky pre-commit/commit-msg 훅으로 검증됨). 새로 이 저장소를 받은 팀원은 최초 1회 `npm install`을 실행해야 훅이 적용됨.
+
+### 내용 작성 규칙
+
+| 구분              | 형식                              | 예시                                     |
+| ----------------- | --------------------------------- | ---------------------------------------- |
+| 공통 컴포넌트     | `공통 컴포넌트 {컴포넌트명} 작업` | `feat: 공통 컴포넌트 GNB 작업`           |
+| 페이지 (퍼블리싱) | `{페이지명} 퍼블리싱 작업`        | `feat: 기사님 찾기 페이지 퍼블리싱 작업` |
+| 페이지 (로직)     | `{페이지명} 기능 작업`            | `feat: 기사님 찾기 페이지 기능 작업`     |
+| 리팩토링          | `{작업명} 리팩토링 작업`          | `refactor: 견적 서비스 리팩토링 작업`    |
+| 설정              | `{작업명} 설정 작업`              | `chore: husky 설정 작업`                 |
+| 그 외             | `{작업명} 기타 작업`              | `feat: GNB 알림 기능 기타 작업`          |
 
 ## 브랜치 전략
 
@@ -94,8 +178,39 @@ main        운영 배포
       └── {type}/{작업명}-{이슈번호}   예: feat/mover-list-page-18
 ```
 
-- 이슈 생성 시 브랜치 함께 생성 → 작업 후 `dev`로 PR → Squash and Merge
-- `dev` 병합에는 승인 2명 필요
+- `main`, `dev`는 **직접 push 불가** (룰셋 보호)
+- `dev` 머지: 승인 **2명** / `main` 머지: 승인 **1명**
+- **Squash and Merge**로 병합, 머지 후 브랜치 자동 삭제
+- 이슈 생성 시 Development에서 브랜치 함께 생성 → 작업 후 `dev`로 PR
+
+### 브랜치 네이밍
+
+`{type}/{작업명}-{이슈번호}`
+
+| 규칙     | 내용                                                      |
+| -------- | --------------------------------------------------------- |
+| type     | 커밋 타입과 동일 (`feat` `fix` `chore` `test` `refactor`) |
+| 구분자   | type과 작업명 사이는 `/`, 그 뒤는 전부 `-`                |
+| 작업명   | 영문 소문자 케밥케이스                                    |
+| 이슈번호 | 맨 뒤에 숫자만                                            |
+| 언어     | 영문만 사용 (한글은 터미널에서 다루기 번거로움)           |
+
+> GitHub 이슈에서 브랜치를 만들면 `12-chore-커밋-타입-추가` 같은 이름이 자동 제안됨 — 위 규칙에 맞게 **직접 수정**해서 생성할 것.
+
+## PR & Issue
+
+### 이슈
+
+- 템플릿 5종 사용 (`feat` `fix` `chore` `test` `refactor`)
+- 이슈 생성 시 브랜치를 함께 생성
+- Projects 보드에 연결 (`무빙_FE`)
+
+### PR
+
+- 템플릿의 모든 항목을 채움
+- **Linked Issue**에 `close #번호`를 반드시 작성 (머지 시 이슈 자동 종료)
+- 리뷰어: 팀장 고정 + 각자 팀원 1명 (팀장이 팀원인 조는 지정하고 싶은 사람으로 지정)
+- 코드 리뷰는 24시간 내 완료
 
 ## 자주 쓰는 명령어
 
@@ -108,9 +223,13 @@ npm run format         # Prettier 전체 덮어쓰기
 npm run format:check   # Prettier 검사만 (안 고침)
 ```
 
+## MCP 작업 시 유의사항
+
+- 이미지·아이콘 등 에셋은 `src/assets/`에 이미 준비되어 있음 — 피그마 MCP 등으로 작업할 때 새로 다운로드하지 말고 기존 `assets/` 폴더 안에서 참조할 것
+
 ## 주의사항
 
 - `node_modules`, `.next`, `out`, `build`는 수정 대상 아님 (ESLint에서도 ignore)
-- 환경 변수는 `.env.example` 참고해서 local의 `.env`에 설정
+- 환경 변수는 `.env`에 두고 절대 커밋하지 않음. `.env.example` 참고해서 local의 `.env`에 설정하고, 새 환경변수 추가 시 `.env.example`에도 반드시 추가하고 팀에 공지
 - `.vscode/settings.json`은 저장소에 커밋되어 있음 — `formatOnType`/`formatOnPaste`를 꺼서 저장 시에만 포맷되게 함 (타이핑 중 자동수정이 겹쳐 파일이 깨지는 문제를 막기 위함). 임의로 되돌리지 말 것
 - 세부 자동화 설정(ESLint 룰별 이유, Prettier 옵션, pre-commit 동작)은 `CODE-QUALITY-AUTOMATION.md` 참고

--- a/CODE-QUALITY-AUTOMATION.md
+++ b/CODE-QUALITY-AUTOMATION.md
@@ -1,0 +1,59 @@
+# 코드 품질 자동화 (Prettier · ESLint · pre-commit · 에디터)
+
+AGENT.md / 팀 컨벤션 문서에서 참조하는 세부 설정 문서입니다.
+
+## Prettier (자동 포맷)
+
+`.prettierrc.json`:
+
+```json
+{
+  "semi": true,
+  "singleQuote": false,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "plugins": ["prettier-plugin-tailwindcss"]
+}
+```
+
+- `prettier-plugin-tailwindcss`: Tailwind 클래스 순서를 규칙대로 자동 정렬 (Tailwind v4 CSS 기반 설정을 자동 인식, 별도 config 불필요)
+- `.prettierignore`: `node_modules`, `.next`, `out`, `build`, `next-env.d.ts` 제외
+- 명령어: `npm run format` (전체 덮어쓰기), `npm run format:check` (검사만, 안 고침)
+
+## ESLint (`eslint.config.mjs`)
+
+`eslint-config-next`(core-web-vitals + typescript) 기반에 아래 커스텀 룰 추가:
+
+| 룰                                      | 내용                                                                                    |
+| --------------------------------------- | --------------------------------------------------------------------------------------- |
+| `no-restricted-imports`                 | 상위 폴더 상대경로(`../`) import 금지 → `@/` 절대경로 사용 (같은 폴더 `./`는 허용)      |
+| `unused-imports/no-unused-imports`      | 안 쓰는 import는 `--fix` 시 자동 삭제 (`@typescript-eslint/no-unused-vars`는 대신 꺼둠) |
+| `unused-imports/no-unused-vars`         | 안 쓰는 변수는 warning (`_` 접두어 붙이면 무시)                                         |
+| `no-multiple-empty-lines`               | 빈 줄 2개 이상 연속되면 `--fix` 시 1개로 압축, 파일 끝 빈 줄은 0개                      |
+| `check-file/filename-naming-convention` | `src/**/*.ts(x)` 파일명은 kebab-case 강제 (자동수정 안 됨, 직접 이름 바꿔야 통과)       |
+
+- 명령어: `npm run lint` (검사만), `npx eslint . --fix` (자동수정까지)
+
+## 커밋 전 자동 검사 (pre-commit)
+
+`git commit` 실행 시 아래 순서로 자동 검사됨. 작성자가 따로 실행할 명령어는 없음 (평소처럼 `git add` · `git commit`만 하면 됨).
+
+1. **pre-commit (lint-staged)** — 스테이징된 파일만 검사
+   - `*.ts, *.tsx, *.js, *.jsx, *.mjs` → `eslint --fix` 실행 후 `prettier --write`
+   - `*.json, *.css, *.md` → `prettier --write`
+   - **자동으로 고쳐지는 것**: 코드 포맷(따옴표·들여쓰기·줄바꿈), Tailwind 클래스 순서, 빈 줄 2개 이상 연속, 안 쓰는 import
+   - **자동으로 안 고쳐지고 커밋이 막히는 것**: 상위 폴더 상대경로(`../`) import 사용, kebab-case 아닌 파일명 등 — 이 경우 터미널(또는 VSCode Source Control 출력창)에 어떤 파일 몇 번째 줄에서 무슨 규칙에 걸렸는지 에러로 뜨며, **직접 코드를 고쳐야** 커밋이 진행됨
+2. **commit-msg (commitlint)** — 커밋 메시지 형식 검사 (`{type}: {내용}`, type 5종만 허용)
+
+> 새로 이 저장소를 받는 팀원은 최초 1회 `npm install`을 실행해야 `pre-commit`/`commit-msg` 훅이 정상 동작함.
+
+## 에디터 설정 (`.vscode/settings.json`, 저장소에 커밋됨)
+
+- 워크스페이스 설정이라 팀원 개인 설정과 무관하게 적용됨 (단, `editor.codeActionsOnSave`는 키 단위로 병합되니 개인 설정에만 있고 워크스페이스엔 없는 키는 살아남음 — 그래서 충돌 나는 키들은 워크스페이스에서 `"never"`로 명시해둠)
+- `editor.formatOnSave: true` / `editor.formatOnType: false` / `editor.formatOnPaste: false`
+- `editor.codeActionsOnSave`: `source.fixAll.eslint`만 켬, `source.fixAll` · `source.organizeImports` · `source.removeUnusedImports`는 `"never"`로 명시 차단 (안 그러면 저장할 때 여러 자동수정이 동시에 돌면서 문서가 깨지는 경우가 있었음)
+- 기본 포맷터는 Prettier로 고정 (`.js/.jsx/.ts/.tsx/.json/.css`)
+- `.vscode/extensions.json`으로 ESLint · Prettier 확장 추천

--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@
 
 ## 🛠 기술 스택
 
-| 구분              | 기술                             |
-| ----------------- | -------------------------------- |
-| **Framework**     | Next.js 16 (App Router)          |
-| **Language**      | TypeScript 6                     |
-| **UI**            | React 19 · Tailwind CSS 4        |
-| **State / Data**  | TanStack Query 5                 |
-| **Form**          | React Hook Form 7                |
-| **Lint / Format** | ESLint 9 · Prettier 3            |
-| **Git Hooks**     | husky · lint-staged · commitlint |
+| 구분              | 기술                                                |
+| ----------------- | --------------------------------------------------- |
+| **Framework**     | Next.js 16 (App Router)                             |
+| **Language**      | TypeScript 6                                        |
+| **UI**            | React 19 · Tailwind CSS 4                           |
+| **State / Data**  | TanStack Query 5                                    |
+| **Form**          | React Hook Form 7                                   |
+| **Lint / Format** | ESLint 9 · Prettier 3 + prettier-plugin-tailwindcss |
+| **Git Hooks**     | husky · lint-staged · commitlint                    |
 
 <br />
 
@@ -112,7 +112,7 @@ src/
 │   ├── loading.tsx
 │   └── globals.css       # 디자인 토큰 · 폰트 · 반응형 브레이크포인트
 ├── assets/               # fonts · icons · images
-├── components/           # 공통 컴포넌트
+├── component/            # 공통 컴포넌트
 ├── hooks/                # 커스텀 훅
 ├── lib/                  # actions · services · utils
 └── providers/            # QueryProvider 등 개별 provider 구현체
@@ -130,9 +130,10 @@ main        운영 배포
       └── {type}/{작업명}-{이슈번호}   예: feat/mover-list-page-18
 ```
 
+- `main`, `dev`는 **직접 push 불가** (룰셋 보호)
+- `dev` 머지: 승인 **2명** / `main` 머지: 승인 **1명**
+- **Squash and Merge**로 병합, 머지 후 브랜치 자동 삭제
 - 이슈 생성 시 브랜치를 함께 생성합니다
-- 작업 완료 후 `dev`로 PR을 올립니다
-- **Squash and Merge**로 병합합니다
 
 ### 커밋 컨벤션
 
@@ -144,12 +145,15 @@ main        운영 배포
 | `test`     | 테스트 코드      |
 | `refactor` | 코드 리팩토링    |
 
+형식: `{type}: {내용}` — 세부 브랜치 네이밍·커밋 내용 규칙은 `AGENT.md` 참고
+
 <br />
 
 ## 🤝 팀 규칙
 
-- 코드 리뷰는 **24시간 내**에 완료합니다
-- `dev` 브랜치 병합에는 **승인 2명**이 필요합니다
+- 이슈 템플릿 5종 사용, 이슈 생성 시 브랜치 함께 생성, Projects 보드(`무빙_FE`) 연결
+- PR은 템플릿 항목 모두 채우고 **Linked Issue**에 `close #번호` 작성
+- 리뷰어는 팀장 고정 + 팀원 1명, 코드 리뷰는 **24시간 내** 완료
 - 4시간 동안 해결되지 않는 문제는 팀에 공유합니다
 - 데일리 스크럼은 전날 퇴실 전 최신화합니다
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.102.8",
+        "@tanstack/react-query-devtools": "^5.102.8",
         "clsx": "^2.1.1",
         "next": "16.3.3",
         "react": "19.2.8",
@@ -19,7 +20,6 @@
         "@commitlint/cli": "^21.2.2",
         "@commitlint/config-conventional": "^21.2.2",
         "@tailwindcss/postcss": "^4",
-        "@tanstack/react-query-devtools": "^5.102.8",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -31,6 +31,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^17.4.1",
         "prettier": "^3.9.6",
+        "prettier-plugin-tailwindcss": "^0.8.1",
         "tailwindcss": "^4",
         "typescript": "^6.0.3"
       }
@@ -2079,7 +2080,6 @@
       "version": "5.102.8",
       "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.102.8.tgz",
       "integrity": "sha512-ZgeMKuF5d/zOE+tgWm3cSbD6Zcbr6IugVsnbHzUcSismqLZDSUPBKM6ILUxExgwe6rPAOox2x5bA5T+PSOQG0Q==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2106,7 +2106,6 @@
       "version": "5.102.8",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.102.8.tgz",
       "integrity": "sha512-QKb7A44BZOU7nxsGA4gFN1fofjYovar5O0T83Ff4Y+2eRq09RGFrAzzutVdF/6/emfSaMDohp6e759BjB3fxEw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tanstack/query-devtools": "5.102.8"
@@ -6574,6 +6573,85 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.8.1.tgz",
+      "integrity": "sha512-iaFMYqDsE4ffdDkn5qup0j5f2aCEBFZrdrZnvu9QKTlWx/iGPeQ4HHu7b7fCPMxeo9nwQBiOAh2nSypdFYWJkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-hermes": "*",
+        "@prettier/plugin-oxc": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-hermes": {
+          "optional": true
+        },
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.102.8",
+    "@tanstack/react-query-devtools": "^5.102.8",
     "clsx": "^2.1.1",
     "next": "16.3.3",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "react-hook-form": "^7.86.0",
-    "@tanstack/react-query-devtools": "^5.102.8"
+    "react-hook-form": "^7.86.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.2.2",
@@ -44,6 +44,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.4.1",
     "prettier": "^3.9.6",
+    "prettier-plugin-tailwindcss": "^0.8.1",
     "tailwindcss": "^4",
     "typescript": "^6.0.3"
   }

--- a/src/app/(auth)/customer/layout.tsx
+++ b/src/app/(auth)/customer/layout.tsx
@@ -1,3 +1,5 @@
-export default function CustomerAuthLayout({ children }: { children: React.ReactNode }) {
+import { type ReactNode } from "react";
+
+export default function CustomerAuthLayout({ children }: { children: ReactNode }) {
   return <div>{children}</div>;
 }

--- a/src/app/(auth)/mover/layout.tsx
+++ b/src/app/(auth)/mover/layout.tsx
@@ -1,3 +1,5 @@
-export default function MoverAuthLayout({ children }: { children: React.ReactNode }) {
+import { type ReactNode } from "react";
+
+export default function MoverAuthLayout({ children }: { children: ReactNode }) {
   return <div>{children}</div>;
 }

--- a/src/app/(protected)/customer/layout.tsx
+++ b/src/app/(protected)/customer/layout.tsx
@@ -1,6 +1,6 @@
-import { type PropsWithChildren } from "react";
+import { type ReactNode } from "react";
 
-export default function CustomerProtectedLayout({ children }: PropsWithChildren) {
+export default function CustomerProtectedLayout({ children }: { children: ReactNode }) {
   // TODO: 세션 체크 + role !== "customer"면 리다이렉트 (인증 로직 구현 후 추가)
   return <div>{children}</div>;
 }

--- a/src/app/(protected)/mover/layout.tsx
+++ b/src/app/(protected)/mover/layout.tsx
@@ -1,6 +1,6 @@
-import { type PropsWithChildren } from "react";
+import { type ReactNode } from "react";
 
-export default function MoverProtectedLayout({ children }: PropsWithChildren) {
+export default function MoverProtectedLayout({ children }: { children: ReactNode }) {
   // TODO: 세션 체크 + role !== "mover"면 리다이렉트 (인증 로직 구현 후 추가)
   return <div>{children}</div>;
 }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -25,8 +25,8 @@ export default function GlobalError({
           <Image src={logo} alt="무빙" className="h-auto w-40" />
           <Image src={errorIcon} alt="" className="h-auto w-60" />
           <div className="flex flex-col gap-3">
-            <h1 className="text-pretendard-50-bold text-orange-400">오류</h1>
-            <p className="text-pretendard-24-regular text-gray-500">
+            <h1 className="text-50 font-bold text-orange-400">오류</h1>
+            <p className="text-24 font-normal text-gray-500">
               문제가 발생했어요
               <br />
               잠시 후 다시 시도해주세요
@@ -34,7 +34,7 @@ export default function GlobalError({
           </div>
           <button
             onClick={() => reset()}
-            className="flex h-12 w-40 items-center justify-center rounded-xl bg-orange-400 text-pretendard-16-semibold text-white tablet:h-13 pc:h-14"
+            className="text-16 tablet:h-13 pc:h-14 flex h-12 w-40 items-center justify-center rounded-xl bg-orange-400 font-semibold text-white"
           >
             다시 시도
           </button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,8 +3,8 @@
 /*
  * 사용법:
  *  색상  -> bg-orange-400, text-black-500, border-line-200 처럼 Tailwind 유틸 그대로 사용
- *  글자  -> text-pretendard-{size}-{weight} 하나로 크기+줄간격+굵기 다 적용됨
- *          예) 버튼 라벨: className="text-pretendard-14-semibold"
+ *  글자  -> text-{size} (font-size+line-height 세트) + font-{weight} 조합해서 사용
+ *          예) 버튼 라벨: className="text-14 font-semibold"
  *  반응형 -> tablet:, pc: 프리픽스 사용 (모바일 375가 기본값, 접두사 없음)
  */
 
@@ -48,6 +48,26 @@
   /* 브레이크포인트 (Figma 프레임 폭 기준: Mobile 375 / Tablet 744 / PC 1920) */
   --breakpoint-tablet: 744px;
   --breakpoint-pc: 1920px;
+
+  /* 타이포그래피: font-size + line-height는 한 세트로 관리, font-weight는 text-*와 조합해서 각자 커스텀 */
+  --text-50: 50px;
+  --text-50--line-height: 42px;
+  --text-32: 32px;
+  --text-32--line-height: 42px;
+  --text-24: 24px;
+  --text-24--line-height: 32px;
+  --text-20: 20px;
+  --text-20--line-height: 32px;
+  --text-18: 18px;
+  --text-18--line-height: 26px;
+  --text-16: 16px;
+  --text-16--line-height: 26px;
+  --text-14: 14px;
+  --text-14--line-height: 24px;
+  --text-13: 13px;
+  --text-13--line-height: 22px;
+  --text-12: 12px;
+  --text-12--line-height: 18px;
 }
 
 @theme inline {
@@ -60,205 +80,6 @@ body {
   background: var(--color-background);
   color: var(--color-foreground);
   font-family: var(--font-sans);
-}
-
-/* 타이포그래피 (Pretendard) */
-@utility text-pretendard-50-bold {
-  font-family: var(--font-sans);
-  font-size: 50px;
-  line-height: 42px;
-  font-weight: 700;
-  letter-spacing: 0;
-}
-
-@utility text-pretendard-32-bold {
-  font-family: var(--font-sans);
-  font-size: 32px;
-  line-height: 42px;
-  font-weight: 700;
-  letter-spacing: 0;
-}
-@utility text-pretendard-32-semibold {
-  font-family: var(--font-sans);
-  font-size: 32px;
-  line-height: 42px;
-  font-weight: 600;
-  letter-spacing: 0;
-}
-@utility text-pretendard-24-bold {
-  font-family: var(--font-sans);
-  font-size: 24px;
-  line-height: 32px;
-  font-weight: 700;
-  letter-spacing: 0;
-}
-@utility text-pretendard-24-semibold {
-  font-family: var(--font-sans);
-  font-size: 24px;
-  line-height: 32px;
-  font-weight: 600;
-  letter-spacing: 0;
-}
-@utility text-pretendard-24-medium {
-  font-family: var(--font-sans);
-  font-size: 24px;
-  line-height: 32px;
-  font-weight: 500;
-  letter-spacing: 0;
-}
-@utility text-pretendard-24-regular {
-  font-family: var(--font-sans);
-  font-size: 24px;
-  line-height: 32px;
-  font-weight: 400;
-  letter-spacing: 0;
-}
-@utility text-pretendard-20-bold {
-  font-family: var(--font-sans);
-  font-size: 20px;
-  line-height: 32px;
-  font-weight: 700;
-  letter-spacing: 0;
-}
-@utility text-pretendard-20-semibold {
-  font-family: var(--font-sans);
-  font-size: 20px;
-  line-height: 32px;
-  font-weight: 600;
-  letter-spacing: 0;
-}
-@utility text-pretendard-20-medium {
-  font-family: var(--font-sans);
-  font-size: 20px;
-  line-height: 32px;
-  font-weight: 500;
-  letter-spacing: 0;
-}
-@utility text-pretendard-20-regular {
-  font-family: var(--font-sans);
-  font-size: 20px;
-  line-height: 32px;
-  font-weight: 400;
-  letter-spacing: 0;
-}
-@utility text-pretendard-18-bold {
-  font-family: var(--font-sans);
-  font-size: 18px;
-  line-height: 26px;
-  font-weight: 700;
-  letter-spacing: 0;
-}
-@utility text-pretendard-18-semibold {
-  font-family: var(--font-sans);
-  font-size: 18px;
-  line-height: 26px;
-  font-weight: 600;
-  letter-spacing: 0;
-}
-@utility text-pretendard-18-medium {
-  font-family: var(--font-sans);
-  font-size: 18px;
-  line-height: 26px;
-  font-weight: 500;
-  letter-spacing: 0;
-}
-@utility text-pretendard-18-regular {
-  font-family: var(--font-sans);
-  font-size: 18px;
-  line-height: 26px;
-  font-weight: 400;
-  letter-spacing: 0;
-}
-@utility text-pretendard-16-bold {
-  font-family: var(--font-sans);
-  font-size: 16px;
-  line-height: 26px;
-  font-weight: 700;
-  letter-spacing: 0;
-}
-@utility text-pretendard-16-semibold {
-  font-family: var(--font-sans);
-  font-size: 16px;
-  line-height: 26px;
-  font-weight: 600;
-  letter-spacing: 0;
-}
-@utility text-pretendard-16-medium {
-  font-family: var(--font-sans);
-  font-size: 16px;
-  line-height: 26px;
-  font-weight: 500;
-  letter-spacing: 0;
-}
-@utility text-pretendard-16-regular {
-  font-family: var(--font-sans);
-  font-size: 16px;
-  line-height: 26px;
-  font-weight: 400;
-  letter-spacing: 0;
-}
-@utility text-pretendard-14-bold {
-  font-family: var(--font-sans);
-  font-size: 14px;
-  line-height: 24px;
-  font-weight: 700;
-  letter-spacing: 0;
-}
-@utility text-pretendard-14-semibold {
-  font-family: var(--font-sans);
-  font-size: 14px;
-  line-height: 24px;
-  font-weight: 600;
-  letter-spacing: 0;
-}
-@utility text-pretendard-14-medium {
-  font-family: var(--font-sans);
-  font-size: 14px;
-  line-height: 24px;
-  font-weight: 500;
-  letter-spacing: 0;
-}
-@utility text-pretendard-14-regular {
-  font-family: var(--font-sans);
-  font-size: 14px;
-  line-height: 24px;
-  font-weight: 400;
-  letter-spacing: 0;
-}
-@utility text-pretendard-13-semibold {
-  font-family: var(--font-sans);
-  font-size: 13px;
-  line-height: 22px;
-  font-weight: 600;
-  letter-spacing: 0;
-}
-@utility text-pretendard-13-medium {
-  font-family: var(--font-sans);
-  font-size: 13px;
-  line-height: 22px;
-  font-weight: 500;
-  letter-spacing: 0;
-}
-@utility text-pretendard-12-semibold {
-  font-family: var(--font-sans);
-  font-size: 12px;
-  line-height: 20px;
-  font-weight: 600;
-  letter-spacing: 0;
-}
-@utility text-pretendard-12-medium {
-  font-family: var(--font-sans);
-  font-size: 12px;
-  line-height: 18px;
-  font-weight: 500;
-  letter-spacing: 0;
-}
-@utility text-pretendard-12-regular {
-  font-family: var(--font-sans);
-  font-size: 12px;
-  line-height: 18px;
-  font-weight: 400;
-  letter-spacing: 0;
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: LayoutProps<"/">) {
   return (
     <html lang="ko" className={`${pretendard.variable} h-full antialiased`}>
-      <body className="min-h-full flex flex-col">
+      <body className="flex min-h-full flex-col">
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -9,8 +9,8 @@ export default function NotFound() {
       <Image src={logo} alt="무빙" className="h-auto w-40" />
       <Image src={notFoundIcon} alt="" className="h-auto w-60" />
       <div className="flex flex-col gap-3">
-        <h1 className="text-pretendard-50-bold text-orange-400">404</h1>
-        <p className="text-pretendard-24-regular text-gray-500">
+        <h1 className="text-50 font-bold text-orange-400">404</h1>
+        <p className="text-24 font-normal text-gray-500">
           페이지를 찾을 수 없어요
           <br />
           요청하신 페이지가 존재하지 않거나 이동되었습니다
@@ -18,7 +18,7 @@ export default function NotFound() {
       </div>
       <Link
         href="/"
-        className="flex h-12 w-40 items-center justify-center rounded-xl bg-orange-400 text-pretendard-16-semibold text-white tablet:h-13 pc:h-14"
+        className="text-16 tablet:h-13 pc:h-14 flex h-12 w-40 items-center justify-center rounded-xl bg-orange-400 font-semibold text-white"
       >
         홈으로 이동
       </Link>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,8 +1,8 @@
 import { QueryProvider } from "@/providers/query-provider";
-import { type PropsWithChildren } from "react";
+import { type ReactNode } from "react";
 // import { AuthProvider } from "@/providers/auth-provider";
 
-export default function Providers({ children }: PropsWithChildren) {
+export default function Providers({ children }: { children: ReactNode }) {
   return (
     <QueryProvider>
       {/* <AuthProvider> */}

--- a/src/providers/query-provider.tsx
+++ b/src/providers/query-provider.tsx
@@ -2,9 +2,9 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { useState, type PropsWithChildren } from "react";
+import { useState, type ReactNode } from "react";
 
-export function QueryProvider({ children }: PropsWithChildren) {
+export function QueryProvider({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
 
   return (


### PR DESCRIPTION
## 📌 개요

- 초기 세팅 컨벤션 정리: 타이포그래피 `@theme`화, `children` 타입 안티패턴 수정, `interface`/`type` 사용 규칙 정리, `prettier-plugin-tailwindcss` 추가, 팀 컨벤션 문서(AGENT.md/README.md) 반영

## 🔢 Linked Issue

- close #16

## 🛠️ 주요 변경 사항

- [x] `globals.css`: `@utility text-pretendard-*` 30개 제거 → `@theme`에 `--text-{size}` + `--text-{size}--line-height` 세트로 정의, weight는 Tailwind 기본 `font-*` 유틸과 조합해서 사용 (`text-16 font-semibold` 형태)
- [x] `children`만 받는 컴포넌트 타입을 `PropsWithChildren`(children 옵셔널이라 안티패턴) 대신 `{ children: ReactNode }`(필수)로 통일 — `providers.tsx`, `query-provider.tsx`, `(auth)`/`(protected)` layout 6개 파일
- [x] `prettier-plugin-tailwindcss` 설치 + `.prettierrc.json`에 등록, 전체 클래스 순서 정렬
- [x] `AGENT.md`: PR&Issue 규칙, 네이밍 컨벤션(변수/함수 접두어/파일/API), 커밋 내용 작성 규칙, API 응답 형식, 버전 관리, 브랜치 세부 규칙, `interface`/`type` 사용 기준, 타입 정의 위치 규칙, MCP 작업 시 asset 참조 규칙 추가
- [x] `README.md`: 브랜치 push 제한·승인 인원·자동삭제, 이슈/PR 템플릿·리뷰어 규칙 반영, 기술스택에 prettier-plugin-tailwindcss 추가
- [x] `CODE-QUALITY-AUTOMATION.md` 신규 생성 (AGENT.md가 참조하던 파일이 없어서 추가)

## 📸 스크린샷 (선택)

- 해당 없음 (설정/문서 작업)

## 🧪 테스트 결과 & 리뷰 요청 사항

- `npm run lint`, `npm run format:check`, `npm run build` 모두 통과 확인
- 컨벤션 문서 중 팀 원본(강사님 공유) 문서는 여전히 `PropsWithChildren` 사용을 권장하고 있어 별도 동기화 필요 — 리뷰 시 참고 부탁드립니다

## 📋 완료 체크리스트

- [x] 브랜치 방향(To dev)을 올바르게 설정했나요?
- [x] 무관한 파일이나 테스트용 코드가 커밋에 포함되지 않았나요?
- [x] (`npm run dev`) 시 에러가 발생하지 않나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * Tailwind CSS 클래스 정렬과 포맷팅이 자동화되었습니다.
  * 텍스트 크기와 줄간격을 조합하는 공통 타이포그래피 체계가 적용되었습니다.
  * 오류 및 404 페이지의 텍스트 스타일이 정리되었습니다.

* **문서**
  * 코드 품질 자동화, 브랜치 전략, 커밋 및 PR 작성 규칙이 문서화되었습니다.

* **개선**
  * 코드 품질 검사를 위한 개발 도구 및 저장 시 자동 포맷 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->