### PR TITLE
Feat: 공통 컴포넌트 Chip 구현

### DIFF
--- a/src/app/(main)/example/page.tsx
+++ b/src/app/(main)/example/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import AddressChip from "@/component/common/chip-address";
+import Chip from "@/component/common/chip-region";
+import MoveTypeChip from "@/component/common/chip-move-type";
+import { useState } from "react";
+
+const REGIONS = [
+  "서울",
+  "경기",
+  "인천",
+  "강원",
+  "충북",
+  "충남",
+  "세종",
+  "대전",
+  "전북",
+  "전남",
+  "광주",
+  "경북",
+  "경남",
+  "대구",
+  "울산",
+  "부산",
+  "제주",
+];
+
+export default function Page() {
+  const [myRegions, setMyRegions] = useState<string[]>([]);
+
+  const toggleRegion = (region: string) => {
+    setMyRegions((prev) =>
+      prev.includes(region) ? prev.filter((r) => r !== region) : [...prev, region]
+    );
+  };
+
+  return (
+    <div className="px-160">
+      <h1 className="mt-6 font-semibold">내가 사는 지역 - md</h1>
+      <p className="text-16 mt-1 text-[#999]">*내가 사는 지역은 언제든 수정 가능해요!</p>
+      <section className="mt-6 flex flex-wrap gap-x-3.5 gap-y-4.5">
+        {REGIONS.map((region) => (
+          <Chip
+            key={region}
+            size="md"
+            className="flex h-11.5 w-18 items-center justify-center"
+            selected={myRegions.includes(region)}
+            onClick={() => toggleRegion(region)}
+          >
+            {region}
+          </Chip>
+        ))}
+      </section>
+      <h2 className="mt-6 font-semibold">내가 사는 지역 - sm</h2>
+      <p className="text-12 mt-2 text-[#999]">*내가 사는 지역은 언제든 수정 가능해요!</p>
+      <section className="mt-6 flex flex-wrap gap-x-2 gap-y-3">
+        {REGIONS.map((region) => (
+          <Chip
+            key={region}
+            size="sm"
+            className="flex h-9 w-12.25 items-center justify-center"
+            selected={myRegions.includes(region)}
+            onClick={() => toggleRegion(region)}
+          >
+            {region}
+          </Chip>
+        ))}
+      </section>
+      <h3 className="mt-6 font-semibold">주소 chip</h3>
+      <section className="mt-3 flex flex-wrap gap-2.5">
+        <AddressChip size="md">도로명</AddressChip>
+        <AddressChip size="sm">도로명</AddressChip>
+        <AddressChip size="md">지번</AddressChip>
+        <AddressChip size="sm">지번</AddressChip>
+      </section>
+      <h4 className="mt-6 font-semibold">이사유형 chip</h4>
+      <section className="mt-3 flex flex-wrap gap-2.5">
+        <MoveTypeChip variant="소형이사" size="md" />
+        <MoveTypeChip variant="소형이사" size="sm" />
+        <MoveTypeChip variant="가정이사" size="md" />
+        <MoveTypeChip variant="가정이사" size="sm" />
+        <MoveTypeChip variant="사무실이사" size="md" />
+        <MoveTypeChip variant="사무실이사" size="sm" />
+        <MoveTypeChip variant="지정견적요청" size="md" />
+        <MoveTypeChip variant="지정견적요청" size="sm" />
+      </section>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,7 +26,7 @@
   --color-black-100: #61605e;
   --color-black-200: #474643;
   --color-black-300: #302f2d;
-  --color-black-400: #1e1e1e;
+  --color-black-400: #262524;
   --color-black-500: #111111;
 
   /* Primary orange (brand) */
@@ -36,8 +36,12 @@
   --color-orange-400: #f9502e;
   --color-orange-500: #e04829;
 
+  /* Secondary red */
+  --color-red-100: #ffeef0;
+  --color-red-200: #ff4f64;
+
   /* Background */
-  --color-background-100: #fcfcfc;
+  --color-background-100: #fafafa;
   --color-background-200: #f7f7f7;
   --color-background-300: #efefef;
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -71,7 +71,7 @@
   --text-13: 13px;
   --text-13--line-height: 22px;
   --text-12: 12px;
-  --text-12--line-height: 18px;
+  --text-12--line-height: 20px;
 }
 
 @theme inline {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,7 +26,7 @@
   --color-black-100: #61605e;
   --color-black-200: #474643;
   --color-black-300: #302f2d;
-  --color-black-400: #262524;
+  --color-black-400: #1e1e1e;
   --color-black-500: #111111;
 
   /* Primary orange (brand) */
@@ -41,7 +41,7 @@
   --color-red-200: #ff4f64;
 
   /* Background */
-  --color-background-100: #fafafa;
+  --color-background-100: #fcfcfc;
   --color-background-200: #f7f7f7;
   --color-background-300: #efefef;
 

--- a/src/component/common/chip-address.tsx
+++ b/src/component/common/chip-address.tsx
@@ -21,7 +21,7 @@ export default function AddressChip({
     <span
       className={clsx(
         "inline-flex items-center self-start rounded-full bg-orange-100 py-0.5 font-semibold text-orange-400",
-        isMd ? "text-14 w-13.5 justify-center px-1" : "text-12 px-1.5 leading-5",
+        isMd ? "text-14 w-13.5 justify-center px-1" : "text-12 px-1.5",
         className
       )}
       {...props}

--- a/src/component/common/chip-address.tsx
+++ b/src/component/common/chip-address.tsx
@@ -1,0 +1,32 @@
+import clsx from "clsx";
+import type { HTMLAttributes, ReactNode } from "react";
+
+type AddressChipSize = "sm" | "md";
+
+interface AddressChipProps extends HTMLAttributes<HTMLSpanElement> {
+  children: ReactNode;
+  size?: AddressChipSize;
+}
+
+// 사용법: <AddressChip size="sm">도로명</AddressChip>
+export default function AddressChip({
+  children,
+  size = "sm",
+  className,
+  ...props
+}: AddressChipProps) {
+  const isMd = size === "md";
+
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center self-start rounded-full bg-orange-100 py-0.5 font-semibold text-orange-400",
+        isMd ? "text-14 w-13.5 justify-center px-1" : "text-12 px-1.5 leading-5",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/component/common/chip-move-type.tsx
+++ b/src/component/common/chip-move-type.tsx
@@ -49,7 +49,7 @@ export default function MoveTypeChip({
         isMd ? "gap-1 rounded-md py-1 pl-1.25" : "gap-0.5 rounded py-0.5 pl-1",
         isMd ? "text-14" : "text-13",
         "font-semibold",
-        isRequested ? "bg-[#ffeef0] text-[#ff4f64]" : "bg-orange-100 text-orange-400",
+        isRequested ? "bg-red-100 text-red-200" : "bg-orange-100 text-orange-400",
         className
       )}
       {...props}

--- a/src/component/common/chip-move-type.tsx
+++ b/src/component/common/chip-move-type.tsx
@@ -1,0 +1,61 @@
+import solidBoxMd from "@/assets/icons/solid-box-md.svg";
+import solidBoxSm from "@/assets/icons/solid-box-sm.svg";
+import solidCompanyMd from "@/assets/icons/solid-company-md.svg";
+import solidCompanySm from "@/assets/icons/solid-company-sm.svg";
+import solidDocumentMd from "@/assets/icons/solid-document-md.svg";
+import solidDocumentSm from "@/assets/icons/solid-document-sm.svg";
+import solidHomeMd from "@/assets/icons/solid-home-md.svg";
+import solidHomeSm from "@/assets/icons/solid-home-sm.svg";
+import clsx from "clsx";
+import Image from "next/image";
+import type { HTMLAttributes } from "react";
+
+type MoveTypeChipVariant = "소형이사" | "사무실이사" | "가정이사" | "지정견적요청";
+type MoveTypeChipSize = "sm" | "md";
+
+interface MoveTypeChipProps extends HTMLAttributes<HTMLSpanElement> {
+  variant: MoveTypeChipVariant;
+  size?: MoveTypeChipSize;
+}
+
+const ICONS: Record<MoveTypeChipVariant, Record<MoveTypeChipSize, string>> = {
+  소형이사: { sm: solidBoxSm, md: solidBoxMd },
+  사무실이사: { sm: solidCompanySm, md: solidCompanyMd },
+  가정이사: { sm: solidHomeSm, md: solidHomeMd },
+  지정견적요청: { sm: solidDocumentSm, md: solidDocumentMd },
+};
+
+const LABELS: Record<MoveTypeChipVariant, string> = {
+  소형이사: "소형이사",
+  사무실이사: "사무실이사",
+  가정이사: "가정이사",
+  지정견적요청: "지정 견적 요청",
+};
+
+// 사용법: <MoveTypeChip variant="소형이사" size="md" />
+export default function MoveTypeChip({
+  variant,
+  size = "sm",
+  className,
+  ...props
+}: MoveTypeChipProps) {
+  const isMd = size === "md";
+  const isRequested = variant === "지정견적요청";
+
+  return (
+    <span
+      className={clsx(
+        "inline-flex shrink-0 items-center self-start pr-1.75",
+        isMd ? "gap-1 rounded-md py-1 pl-1.25" : "gap-0.5 rounded py-0.5 pl-1",
+        isMd ? "text-14" : "text-13",
+        "font-semibold",
+        isRequested ? "bg-[#ffeef0] text-[#ff4f64]" : "bg-orange-100 text-orange-400",
+        className
+      )}
+      {...props}
+    >
+      <Image src={ICONS[variant][size]} alt="" className="size-5 shrink-0" />
+      {LABELS[variant]}
+    </span>
+  );
+}

--- a/src/component/common/chip-region.tsx
+++ b/src/component/common/chip-region.tsx
@@ -30,7 +30,7 @@ export default function Chip({
         weightClass,
         selected
           ? "border-orange-400 bg-orange-100 text-orange-400"
-          : "border-gray-300 bg-[#fafafa] text-[#262524]",
+          : "bg-background-100 text-black-400 border-gray-300",
         className
       )}
       {...props}

--- a/src/component/common/chip-region.tsx
+++ b/src/component/common/chip-region.tsx
@@ -30,7 +30,7 @@ export default function Chip({
         weightClass,
         selected
           ? "border-orange-400 bg-orange-100 text-orange-400"
-          : "bg-background-100 text-black-400 border-gray-300",
+          : "border-gray-300 bg-[#fafafa] text-[#262524]",
         className
       )}
       {...props}

--- a/src/component/common/chip-region.tsx
+++ b/src/component/common/chip-region.tsx
@@ -1,0 +1,41 @@
+import clsx from "clsx";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+type ChipSize = "sm" | "md";
+
+interface ChipProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+  size?: ChipSize;
+  selected?: boolean;
+}
+
+// 사용법: <Chip size="md" selected={selected} onClick={() => setSelected(!selected)}>서울</Chip>
+export default function Chip({
+  children,
+  size = "sm",
+  selected = false,
+  className,
+  ...props
+}: ChipProps) {
+  const isMd = size === "md";
+  const weightClass = selected || !isMd ? "font-medium" : "font-normal";
+
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      className={clsx(
+        "self-start rounded-full border whitespace-nowrap",
+        isMd ? "text-18 px-5 py-2.5" : "text-14 px-3 py-1.5",
+        weightClass,
+        selected
+          ? "border-orange-400 bg-orange-100 text-orange-400"
+          : "border-gray-300 bg-[#fafafa] text-[#262524]",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## 📌 개요

- 피그마 "Chip" 컴포넌트 3종(chip/지역, Chip/이사유형, chip/address) 구현, 사용 예시 페이지 추가, 구현 중 발견한 `globals.css` 색상 토큰 불일치 수정
- /example 경로로 작업 내용 확인 가능합니다. (merge 시 삭제 예정)

## 🔢 Linked Issue

- close #24

## 🛠️ 주요 변경 사항

- [x] `chip-region.tsx`: 지역 필터용 토글 칩 (`Chip`) — `size`(sm/md) × `selected` 상태, 클릭 시 선택/해제 토글
- [x] `chip-move-type.tsx`: 이사유형 태그 (`MoveTypeChip`) — 소형이사/가정이사/사무실이사/지정견적요청 variant별 아이콘+색상, 기존 `assets/icons` 아이콘 재사용
- [x] `chip-address.tsx`: 주소 뱃지 (`AddressChip`) — children으로 라벨(도로명/지번 등) 받는 단순 pill
- [x] 3개 컴포넌트 모두 임의 부모 flex 레이아웃에서 늘어나지 않도록 `self-start` 방어 처리
- [x] `globals.css`: 피그마 실제 값 기준으로 `black-400`(`#1e1e1e`→`#262524`), `background-100`(`#fcfcfc`→`#fafafa`) 수정, 없던 `red-100`/`red-200` 토큰 추가 — 두 컴포넌트에서 쓰던 arbitrary value 전부 토큰으로 교체
- [x] `src/app/(main)/example/page.tsx`: 세 컴포넌트 전체 variant/size 조합 확인용 예시 페이지 추가

## 📸 스크린샷 (선택)
<img width="662" height="694" alt="image" src="https://github.com/user-attachments/assets/0f7a4bf4-59b4-4fa3-941c-df313d21f65c" />


- `/example` 페이지에서 지역 chip(선택 토글 포함), 주소 chip, 이사유형 chip 전체 variant 렌더링 확인

## 🧪 테스트 결과 & 리뷰 요청 사항

- `npm run lint`, `npx tsc --noEmit`, `npm run build` 모두 통과 확인
- 브라우저에서 지역 chip 클릭 토글(선택/해제) 실제 동작 확인

## 📋 완료 체크리스트

- [x] 브랜치 방향(To dev)을 올바르게 설정했나요?
- [x] 무관한 파일이나 테스트용 코드가 커밋에 포함되지 않았나요?
- [x] (`npm run dev`) 시 에러가 발생하지 않나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 지역 선택 상태를 확인할 수 있는 예시 페이지를 추가했습니다.
  * 대·소형 지역, 주소, 이사 유형을 칩 형태로 표시합니다.
  * 지역 칩을 클릭해 선택 상태를 전환할 수 있습니다.
  * 주소 칩과 이사 유형 칩의 크기 및 유형별 표시를 지원합니다.

* **스타일**
  * 칩의 선택 상태를 구분하기 위한 색상과 테두리 스타일을 적용했습니다.
  * 보조 빨강 색상을 추가하고 작은 텍스트의 줄 간격을 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->