### PR TITLE
feat: 공통 컴포넌트 Tab 작업

### DIFF
--- a/src/app/(main)/component-tab/page.tsx
+++ b/src/app/(main)/component-tab/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState } from "react";
+import Tab from "@/component/common/tab";
+
+export default function TabPage() {
+  const [quoteTab, setQuoteTab] = useState<"waiting" | "received">("waiting");
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col gap-8 p-10">
+      <section className="flex flex-col gap-3">
+        <h2 className="text-14 font-semibold text-gray-500">단일 상태 (active / default)</h2>
+        <div className="flex">
+          <Tab active>선택된 탭</Tab>
+          <Tab>선택 안 된 탭</Tab>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-14 font-semibold text-gray-500">
+          인터랙션 — 클릭으로 탭 전환 (모바일/태블릿: 폭 균등 분배, PC: 가운데 정렬)
+        </h2>
+        <div className="border-line-100 pc:justify-center pc:gap-8 flex border-b">
+          <Tab active={quoteTab === "waiting"} onClick={() => setQuoteTab("waiting")}>
+            대기 중인 견적
+          </Tab>
+          <Tab active={quoteTab === "received"} onClick={() => setQuoteTab("received")}>
+            받았던 견적
+          </Tab>
+        </div>
+        <p className="text-14 text-gray-500">현재 선택: {quoteTab}</p>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-14 font-semibold text-gray-500">disabled</h2>
+        <div className="flex">
+          <Tab active disabled>
+            비활성 탭
+          </Tab>
+          <Tab disabled>비활성 탭</Tab>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(main)/component-tab/page.tsx
+++ b/src/app/(main)/component-tab/page.tsx
@@ -2,44 +2,24 @@
 
 import { useState } from "react";
 import Tab from "@/component/common/tab";
+import TabList from "@/component/common/tab-list";
 
 export default function TabPage() {
   const [quoteTab, setQuoteTab] = useState<"waiting" | "received">("waiting");
 
   return (
-    <div className="mx-auto flex max-w-md flex-col gap-8 p-10">
-      <section className="flex flex-col gap-3">
-        <h2 className="text-14 font-semibold text-gray-500">단일 상태 (active / default)</h2>
-        <div className="flex">
-          <Tab active>선택된 탭</Tab>
-          <Tab>선택 안 된 탭</Tab>
-        </div>
-      </section>
-
-      <section className="flex flex-col gap-3">
-        <h2 className="text-14 font-semibold text-gray-500">
-          인터랙션 — 클릭으로 탭 전환 (모바일/태블릿: 폭 균등 분배, PC: 가운데 정렬)
-        </h2>
-        <div className="border-line-100 pc:justify-center pc:gap-8 flex border-b">
-          <Tab active={quoteTab === "waiting"} onClick={() => setQuoteTab("waiting")}>
-            대기 중인 견적
-          </Tab>
-          <Tab active={quoteTab === "received"} onClick={() => setQuoteTab("received")}>
-            받았던 견적
-          </Tab>
-        </div>
-        <p className="text-14 text-gray-500">현재 선택: {quoteTab}</p>
-      </section>
-
-      <section className="flex flex-col gap-3">
-        <h2 className="text-14 font-semibold text-gray-500">disabled</h2>
-        <div className="flex">
-          <Tab active disabled>
-            비활성 탭
-          </Tab>
-          <Tab disabled>비활성 탭</Tab>
-        </div>
-      </section>
+    <div>
+      {/* 브라우저 폭을 376px / 745px 기준으로 늘려보면 모바일 → 태블릿 → PC 순으로 스타일이 바뀜 */}
+      <p className="text-14 p-4 font-semibold text-gray-500">브라우저 폭을 조정해서 확인해보세요</p>
+      <TabList>
+        <Tab active={quoteTab === "waiting"} onClick={() => setQuoteTab("waiting")}>
+          대기 중인 견적
+        </Tab>
+        <Tab active={quoteTab === "received"} onClick={() => setQuoteTab("received")}>
+          받았던 견적
+        </Tab>
+      </TabList>
+      <p className="text-14 p-4 text-gray-500">현재 선택: {quoteTab}</p>
     </div>
   );
 }

--- a/src/app/(main)/component-tab/page.tsx
+++ b/src/app/(main)/component-tab/page.tsx
@@ -9,17 +9,49 @@ export default function TabPage() {
 
   return (
     <div>
-      {/* 브라우저 폭을 376px / 745px 기준으로 늘려보면 모바일 → 태블릿 → PC 순으로 스타일이 바뀜 */}
       <p className="text-14 p-4 font-semibold text-gray-500">브라우저 폭을 조정해서 확인해보세요</p>
-      <TabList>
-        <Tab active={quoteTab === "waiting"} onClick={() => setQuoteTab("waiting")}>
+
+      <TabList aria-label="견적 탭">
+        <Tab
+          id="tab-waiting"
+          controls="panel-waiting"
+          active={quoteTab === "waiting"}
+          onClick={() => setQuoteTab("waiting")}
+        >
           대기 중인 견적
         </Tab>
-        <Tab active={quoteTab === "received"} onClick={() => setQuoteTab("received")}>
+        <Tab
+          id="tab-received"
+          controls="panel-received"
+          active={quoteTab === "received"}
+          onClick={() => setQuoteTab("received")}
+        >
           받았던 견적
         </Tab>
       </TabList>
-      <p className="text-14 p-4 text-gray-500">현재 선택: {quoteTab}</p>
+
+      {quoteTab === "waiting" && (
+        <div
+          id="panel-waiting"
+          role="tabpanel"
+          aria-labelledby="tab-waiting"
+          tabIndex={0}
+          className="text-14 p-4 text-gray-500"
+        >
+          대기 중인 견적 목록 (예시 콘텐츠)
+        </div>
+      )}
+      {quoteTab === "received" && (
+        <div
+          id="panel-received"
+          role="tabpanel"
+          aria-labelledby="tab-received"
+          tabIndex={0}
+          className="text-14 p-4 text-gray-500"
+        >
+          받았던 견적 목록 (예시 콘텐츠)
+        </div>
+      )}
     </div>
   );
 }

--- a/src/component/common/tab-list.tsx
+++ b/src/component/common/tab-list.tsx
@@ -1,0 +1,23 @@
+import clsx from "clsx";
+import type { HTMLAttributes, ReactNode } from "react";
+
+interface TabListProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export default function TabList({ children, className, ...props }: TabListProps) {
+  return (
+    <div
+      role="tablist"
+      className={clsx(
+        "border-line-100 flex w-full items-center gap-6 border-b bg-gray-50 px-6 py-2.5",
+        "tablet:px-18 tablet:shadow-[0px_2px_5px_rgba(248,248,248,0.2)]",
+        "pc:items-start pc:gap-8 pc:px-[360px] pc:pt-4 pc:pb-0 pc:shadow-[0px_2px_5px_rgba(248,248,248,0.1)]",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/component/common/tab-list.tsx
+++ b/src/component/common/tab-list.tsx
@@ -1,14 +1,56 @@
+"use client";
+
 import clsx from "clsx";
-import type { HTMLAttributes, ReactNode } from "react";
+import type { HTMLAttributes, KeyboardEvent, ReactNode } from "react";
+import { useRef } from "react";
 
 interface TabListProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
 }
 
-export default function TabList({ children, className, ...props }: TabListProps) {
+export default function TabList({ children, className, onKeyDown, ...props }: TabListProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    onKeyDown?.(event);
+
+    const tabs = Array.from(
+      listRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]') ?? []
+    );
+    if (tabs.length === 0) return;
+
+    const currentIndex = tabs.findIndex((tab) => tab === document.activeElement);
+    if (currentIndex === -1) return;
+
+    let nextIndex: number | null = null;
+    switch (event.key) {
+      case "ArrowRight":
+        nextIndex = (currentIndex + 1) % tabs.length;
+        break;
+      case "ArrowLeft":
+        nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+        break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      case "End":
+        nextIndex = tabs.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    const nextTab = tabs[nextIndex];
+    nextTab.focus();
+    nextTab.click();
+  };
+
   return (
     <div
+      ref={listRef}
       role="tablist"
+      onKeyDown={handleKeyDown}
       className={clsx(
         "border-line-100 flex w-full items-center gap-6 border-b bg-gray-50 px-6 py-2.5",
         "tablet:px-18 tablet:shadow-[0px_2px_5px_rgba(248,248,248,0.2)]",

--- a/src/component/common/tab.tsx
+++ b/src/component/common/tab.tsx
@@ -1,0 +1,35 @@
+import clsx from "clsx";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+interface TabProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+  // 현재 선택된 탭인지 — 하단 인디케이터(border)와 텍스트 색상/굵기가 바뀜
+  active?: boolean;
+}
+
+export default function Tab({
+  children,
+  active = false,
+  className,
+  type = "button",
+  ...props
+}: TabProps) {
+  return (
+    <button
+      type={type}
+      role="tab"
+      aria-selected={active}
+      className={clsx(
+        "text-14 flex h-[54px] flex-1 shrink-0 items-center justify-center border-b-2 border-solid whitespace-nowrap",
+        "pc:h-auto pc:flex-none pc:py-4 pc:text-20",
+        active
+          ? "border-black-400 text-black-500 pc:font-semibold font-bold"
+          : "border-transparent font-semibold text-gray-400",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/component/common/tab.tsx
+++ b/src/component/common/tab.tsx
@@ -29,8 +29,8 @@ export default function Tab({
         "text-14 flex h-[54px] shrink-0 items-center border-b-2 border-solid whitespace-nowrap",
         "pc:h-auto pc:py-4 pc:text-20",
         active
-          ? "border-black-400 text-black-500 pc:border-black-500 pc:font-semibold font-bold"
-          : "border-transparent font-semibold text-gray-400",
+          ? "border-black-black-400 text-black-500 pc:border-black-500 pc:font-semibold font-bold"
+          : "text-gray-gray-400 border-transparent font-semibold",
         className
       )}
       {...props}

--- a/src/component/common/tab.tsx
+++ b/src/component/common/tab.tsx
@@ -3,10 +3,14 @@ import type { ButtonHTMLAttributes, ReactNode } from "react";
 
 interface TabProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
-  // 현재 선택된 탭인지 — 하단 인디케이터(border)와 텍스트 색상/굵기가 바뀜
+  // 현재 선택된 탭인지 — 하단 인디케이터(border)와 텍스트 색상/굵기/크기가 바뀜
   active?: boolean;
 }
 
+// 폭은 텍스트 길이만큼만 차지 (flex-1로 늘리지 않음) — 여러 개를 나열할 때
+// 부모(TabList)의 gap으로 간격을 맞춤. 반응형: 모바일·태블릿은 동일, PC(pc:)만 다름
+// - 모바일/태블릿: h-[54px], text-14, active → border-black-400 + font-bold
+// - PC: 높이 자동(py-4), text-20, active여도 font-semibold(bold 아님) + border-black-500
 export default function Tab({
   children,
   active = false,
@@ -20,10 +24,10 @@ export default function Tab({
       role="tab"
       aria-selected={active}
       className={clsx(
-        "text-14 flex h-[54px] flex-1 shrink-0 items-center justify-center border-b-2 border-solid whitespace-nowrap",
-        "pc:h-auto pc:flex-none pc:py-4 pc:text-20",
+        "text-14 flex h-[54px] shrink-0 items-center border-b-2 border-solid whitespace-nowrap",
+        "pc:h-auto pc:py-4 pc:text-20",
         active
-          ? "border-black-400 text-black-500 pc:font-semibold font-bold"
+          ? "border-black-400 text-black-500 pc:border-black-500 pc:font-semibold font-bold"
           : "border-transparent font-semibold text-gray-400",
         className
       )}

--- a/src/component/common/tab.tsx
+++ b/src/component/common/tab.tsx
@@ -3,26 +3,28 @@ import type { ButtonHTMLAttributes, ReactNode } from "react";
 
 interface TabProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
-  // 현재 선택된 탭인지 — 하단 인디케이터(border)와 텍스트 색상/굵기/크기가 바뀜
   active?: boolean;
+  id: string;
+  controls: string;
 }
 
-// 폭은 텍스트 길이만큼만 차지 (flex-1로 늘리지 않음) — 여러 개를 나열할 때
-// 부모(TabList)의 gap으로 간격을 맞춤. 반응형: 모바일·태블릿은 동일, PC(pc:)만 다름
-// - 모바일/태블릿: h-[54px], text-14, active → border-black-400 + font-bold
-// - PC: 높이 자동(py-4), text-20, active여도 font-semibold(bold 아님) + border-black-500
 export default function Tab({
   children,
   active = false,
+  id,
+  controls,
   className,
   type = "button",
   ...props
 }: TabProps) {
   return (
     <button
+      id={id}
       type={type}
       role="tab"
       aria-selected={active}
+      aria-controls={controls}
+      tabIndex={active ? 0 : -1}
       className={clsx(
         "text-14 flex h-[54px] shrink-0 items-center border-b-2 border-solid whitespace-nowrap",
         "pc:h-auto pc:py-4 pc:text-20",


### PR DESCRIPTION
## 📌 개요

- 공통 컴포넌트 Tab/TabList 구현 (모바일·태블릿·PC 반응형) 및 예시(테스트) 페이지 추가

## 🔢 Linked Issue

- close #30 

## 🛠️ 주요 변경 사항

- [x] `src/component/common/tab.tsx` - 탭 버튼 (active/default, 반응형 텍스트 크기·굵기·밑줄 색)
- [x] `src/component/common/tab-list.tsx` - 탭바 래퍼 (반응형 padding/gap/그림자)
- [x] `src/app/(main)/component-tab/page.tsx` - 컴포넌트 상태별 예시 페이지

## 🧪 테스트 결과 & 리뷰 요청 사항

- `npx tsc --noEmit` 통과
- `/component-tab` 경로에서 브라우저 폭 744px / 1920px 기준 반응형 확인 가능
- 추후 브레이크 포인트 수정예정이라 현재 테스트는 위 기준으로 봐주셔야합니다.

## 📋 완료 체크리스트

- [x] 브랜치 방향(To dev)을 올바르게 설정했나요?
- [x] 무관한 파일이나 테스트용 코드가 커밋에 포함되지 않았나요?
- [x] (`npm run dev`) 시 에러가 발생하지 않나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 대기 중인 견적과 받았던 견적을 쉽게 전환해 확인할 수 있는 탭 화면을 추가했습니다.
  - 현재 선택된 탭이 시각적으로 구분되어 탐색 상태를 명확히 확인할 수 있습니다.
  - 모바일, 태블릿, PC 등 화면 크기에 맞춰 레이아웃과 여백이 자동으로 조정됩니다.
  - 탭 영역은 키보드 및 보조 기술을 고려한 접근성 속성을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->