### PR TITLE
fix: 이용서비스/지역/이사유형 chip 값 api enum 기준으로 수정

### DIFF
--- a/src/app/(main)/component-chip/page.tsx
+++ b/src/app/(main)/component-chip/page.tsx
@@ -1,30 +1,48 @@
 "use client";
 
 import AddressChip from "@/component/common/chip-address";
-import Chip from "@/component/common/chip-region";
+import Chip, {
+  REGION_LABELS,
+  REGIONS,
+  SERVICE_LABELS,
+  SERVICES,
+} from "@/component/common/chip-region";
 import MoveTypeChip from "@/component/common/chip-move-type";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 
-const REGIONS = [
-  "서울",
-  "경기",
-  "인천",
-  "강원",
-  "충북",
-  "충남",
-  "세종",
-  "대전",
-  "전북",
-  "전남",
-  "광주",
-  "경북",
-  "경남",
-  "대구",
-  "울산",
-  "부산",
-  "제주",
-];
-const MOVE_TYPE = ["소형이사", "가정이사", "사무실이사"];
+// GET /estimate/mover-requests 응답 예시 (mover가 받은 요청 목록) — category는 raw enum(SMALL/HOME/OFFICE) 그대로 내려옴
+// isTargeted는 실제 응답 필드가 아니라 지정 요청 탭(쿼리파라미터)에서 온 건지로 FE가 판단하는 값 — 데모용으로 같이 표기
+const MOCK_REQUESTS = [
+  {
+    id: 101,
+    category: "SMALL",
+    movingDate: "2026-09-20",
+    quotationStatus: "PENDING",
+    isTargeted: false,
+  },
+  {
+    id: 102,
+    category: "HOME",
+    movingDate: "2026-09-22",
+    quotationStatus: "PENDING",
+    isTargeted: false,
+  },
+  {
+    id: 103,
+    category: "OFFICE",
+    movingDate: "2026-09-25",
+    quotationStatus: "PENDING",
+    isTargeted: false,
+  },
+  {
+    id: 104,
+    category: "SMALL",
+    movingDate: "2026-09-28",
+    quotationStatus: "PENDING",
+    isTargeted: true,
+  },
+] as const;
+
 export default function Page() {
   const [myRegions, setMyRegions] = useState<string[]>([]);
 
@@ -47,7 +65,7 @@ export default function Page() {
             selected={myRegions.includes(region)}
             onClick={() => toggleRegion(region)}
           >
-            {region}
+            {REGION_LABELS[region]}
           </Chip>
         ))}
       </section>
@@ -62,7 +80,7 @@ export default function Page() {
             selected={myRegions.includes(region)}
             onClick={() => toggleRegion(region)}
           >
-            {region}
+            {REGION_LABELS[region]}
           </Chip>
         ))}
       </section>
@@ -71,7 +89,7 @@ export default function Page() {
         *이용 서비스는 중복 선택 가능하며, 언제든 수정 가능해요!
       </p>
       <section className="mt-6 flex flex-wrap gap-x-3.5 gap-y-4.5">
-        {MOVE_TYPE.map((m_t) => (
+        {SERVICES.map((m_t) => (
           <Chip
             key={m_t}
             size="md"
@@ -79,7 +97,7 @@ export default function Page() {
             selected={myRegions.includes(m_t)}
             onClick={() => toggleRegion(m_t)}
           >
-            {m_t}
+            {SERVICE_LABELS[m_t]}
           </Chip>
         ))}
       </section>
@@ -88,7 +106,7 @@ export default function Page() {
         *이용 서비스는 중복 선택 가능하며, 언제든 수정 가능해요!
       </p>
       <section className="mt-6 flex flex-wrap gap-x-3.5 gap-y-4.5">
-        {MOVE_TYPE.map((m_t) => (
+        {SERVICES.map((m_t) => (
           <Chip
             key={m_t}
             size="sm"
@@ -96,7 +114,7 @@ export default function Page() {
             selected={myRegions.includes(m_t)}
             onClick={() => toggleRegion(m_t)}
           >
-            {m_t}
+            {SERVICE_LABELS[m_t]}
           </Chip>
         ))}
       </section>
@@ -107,16 +125,14 @@ export default function Page() {
         <AddressChip size="md">지번</AddressChip>
         <AddressChip size="sm">지번</AddressChip>
       </section>
-      <h4 className="mt-6 font-semibold">이사유형 chip</h4>
+      <h4 className="mt-6 font-semibold">이사유형 chip (mock 응답 기반)</h4>
       <section className="mt-3 flex flex-wrap gap-2.5">
-        <MoveTypeChip variant="소형이사" size="md" />
-        <MoveTypeChip variant="소형이사" size="sm" />
-        <MoveTypeChip variant="가정이사" size="md" />
-        <MoveTypeChip variant="가정이사" size="sm" />
-        <MoveTypeChip variant="사무실이사" size="md" />
-        <MoveTypeChip variant="사무실이사" size="sm" />
-        <MoveTypeChip variant="지정견적요청" size="md" />
-        <MoveTypeChip variant="지정견적요청" size="sm" />
+        {MOCK_REQUESTS.map((request) => (
+          <Fragment key={request.id}>
+            <MoveTypeChip variant={request.isTargeted ? "TARGETED" : request.category} size="md" />
+            <MoveTypeChip variant={request.isTargeted ? "TARGETED" : request.category} size="sm" />
+          </Fragment>
+        ))}
       </section>
     </div>
   );

--- a/src/component/common/chip-move-type.tsx
+++ b/src/component/common/chip-move-type.tsx
@@ -9,8 +9,10 @@ import solidHomeSm from "@/assets/icons/solid-home-sm.svg";
 import clsx from "clsx";
 import Image from "next/image";
 import type { HTMLAttributes } from "react";
+import type { ServiceCode } from "./chip-region";
 
-type MoveTypeChipVariant = "소형이사" | "사무실이사" | "가정이사" | "지정견적요청";
+// TARGETED는 BE ServiceType이 아니라 FE에서 판단하는 지정견적요청 표시 — isTargeted는 응답 필드가 아니라 요청 목록 조회용 쿼리 파라미터라 category enum에 못 낌
+type MoveTypeChipVariant = ServiceCode | "TARGETED";
 type MoveTypeChipSize = "sm" | "md";
 
 interface MoveTypeChipProps extends HTMLAttributes<HTMLSpanElement> {
@@ -19,20 +21,20 @@ interface MoveTypeChipProps extends HTMLAttributes<HTMLSpanElement> {
 }
 
 const ICONS: Record<MoveTypeChipVariant, Record<MoveTypeChipSize, string>> = {
-  소형이사: { sm: solidBoxSm, md: solidBoxMd },
-  사무실이사: { sm: solidCompanySm, md: solidCompanyMd },
-  가정이사: { sm: solidHomeSm, md: solidHomeMd },
-  지정견적요청: { sm: solidDocumentSm, md: solidDocumentMd },
+  SMALL: { sm: solidBoxSm, md: solidBoxMd },
+  OFFICE: { sm: solidCompanySm, md: solidCompanyMd },
+  HOME: { sm: solidHomeSm, md: solidHomeMd },
+  TARGETED: { sm: solidDocumentSm, md: solidDocumentMd },
 };
 
 const LABELS: Record<MoveTypeChipVariant, string> = {
-  소형이사: "소형이사",
-  사무실이사: "사무실이사",
-  가정이사: "가정이사",
-  지정견적요청: "지정 견적 요청",
+  SMALL: "소형이사",
+  OFFICE: "사무실이사",
+  HOME: "가정이사",
+  TARGETED: "지정 견적 요청",
 };
 
-// 사용법: <MoveTypeChip variant="소형이사" size="md" />
+// 사용법: <MoveTypeChip variant="SMALL" size="md" />
 export default function MoveTypeChip({
   variant,
   size = "sm",
@@ -40,7 +42,7 @@ export default function MoveTypeChip({
   ...props
 }: MoveTypeChipProps) {
   const isMd = size === "md";
-  const isRequested = variant === "지정견적요청";
+  const isRequested = variant === "TARGETED";
 
   return (
     <span

--- a/src/component/common/chip-region.tsx
+++ b/src/component/common/chip-region.tsx
@@ -9,6 +9,57 @@ interface ChipProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   selected?: boolean;
 }
 
+// BE RegionType과 값 맞춤 (지역 선택 그대로 profile API로 전송)
+export type RegionCode =
+  | "SEOUL"
+  | "GYEONGGI"
+  | "INCHEON"
+  | "GANGWON"
+  | "CHUNGBUK"
+  | "CHUNGNAM"
+  | "SEJONG"
+  | "DAEJEON"
+  | "JEONBUK"
+  | "JEONNAM"
+  | "GWANGJU"
+  | "GYEONGBUK"
+  | "GYEONGNAM"
+  | "DAEGU"
+  | "ULSAN"
+  | "BUSAN"
+  | "JEJU";
+
+export const REGION_LABELS: Record<RegionCode, string> = {
+  SEOUL: "서울",
+  GYEONGGI: "경기",
+  INCHEON: "인천",
+  GANGWON: "강원",
+  CHUNGBUK: "충북",
+  CHUNGNAM: "충남",
+  SEJONG: "세종",
+  DAEJEON: "대전",
+  JEONBUK: "전북",
+  JEONNAM: "전남",
+  GWANGJU: "광주",
+  GYEONGBUK: "경북",
+  GYEONGNAM: "경남",
+  DAEGU: "대구",
+  ULSAN: "울산",
+  BUSAN: "부산",
+  JEJU: "제주",
+};
+export const REGIONS = Object.keys(REGION_LABELS) as RegionCode[];
+
+// BE ServiceType과 값 맞춤 (이용 서비스 선택 그대로 profile API로 전송)
+export type ServiceCode = "SMALL" | "HOME" | "OFFICE";
+
+export const SERVICE_LABELS: Record<ServiceCode, string> = {
+  SMALL: "소형이사",
+  HOME: "가정이사",
+  OFFICE: "사무실이사",
+};
+export const SERVICES = Object.keys(SERVICE_LABELS) as ServiceCode[];
+
 // 사용법: <Chip size="md" selected={selected} onClick={() => setSelected(!selected)}>서울</Chip>
 export default function Chip({
   children,


### PR DESCRIPTION
## 📌 개요

- 지역/이용서비스/이사유형 선택 Chip이 한글 라벨을 그대로 값으로 쓰고 있어서, 그대로 제출하면 BE `z.enum(RegionType/ServiceType)` 검증에서 400 나는 문제를 고침

## 🔢 Linked Issue

- close #39

## 🛠️ 주요 변경 사항

- [x] `chip-region.tsx`에 `REGION_LABELS`/`REGIONS`, `SERVICE_LABELS`/`SERVICES` export 추가 (BE `RegionType`/`ServiceType` enum 값 그대로 키로 사용)
- [x] `MoveTypeChip`의 `variant`도 `SMALL`/`HOME`/`OFFICE`(+ FE 전용 `TARGETED`)로 전환, `chip-region.tsx`의 `ServiceCode` 재사용
- [x] `component-chip/page.tsx`는 위정리, 이사유형 chip 섹션은 `GET/estimate/mover-requests` 응답을 흉내낸 mock 데이터 기반으로 데모

## 📸 스크린샷 (선택)

-

## 🧪 테스트 결과 & 리뷰 요청 사항

- `npx tsc --noEmit`, `npm run lint` 통과
- `isTargeted`는 실제 응답 필드가 아 터라, mock에도 그렇게 표시해뒀는데이 처리 방식 맞는지 리뷰 요청

## 📋 완료 체크리스트

- [x] 브랜치 방향(To dev)을 올바르게 설정했나요?
- [x] 무관한 파일이나 테스트용 코드
- [x] (`npm run dev`) 시 에러가 발생하지 않나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 지역 및 서비스 선택 칩이 표준화된 지역·서비스 정보와 한글 라벨을 사용해 표시됩니다.
  * 이사 유형 칩이 요청 데이터에 따라 동적으로 표시됩니다.
  * 지정 견적 요청 상태를 별도 칩으로 구분해 보여줍니다.

* **개선**
  * 이사 유형 표시가 한글 값이 아닌 표준 코드 기반으로 일관되게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->