### PR TITLE
feat: 공통 컴포넌트 Button xs 사이즈 추가

### DIFF
--- a/src/app/(main)/component-button/page.tsx
+++ b/src/app/(main)/component-button/page.tsx
@@ -16,6 +16,18 @@ export default function ButtonPage() {
   return (
     <div className="mx-auto flex max-w-md flex-col gap-8 p-10">
       <section className="flex flex-col gap-3">
+        <h2 className="text-14 font-semibold text-gray-500">solid / xs (헤더 로그인 버튼)</h2>
+        <div className="w-[116px]">
+          <Button size="xs">로그인</Button>
+        </div>
+        <div className="w-[116px]">
+          <Button size="xs" disabled>
+            로그인
+          </Button>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-3">
         <h2 className="text-14 font-semibold text-gray-500">solid / sm</h2>
         <Button size="sm">Primary CTA 버튼</Button>
         <Button size="sm" disabled>

--- a/src/component/common/button.tsx
+++ b/src/component/common/button.tsx
@@ -2,17 +2,27 @@ import clsx from "clsx";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
 type ButtonVariant = "solid" | "outlined";
-type ButtonSize = "sm" | "md";
+type ButtonSize = "xs" | "sm" | "md";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   // solid: 배경을 채운 primary CTA / outlined: 테두리만 있는 보조 CTA — 크기·형태가 같아 한 컴포넌트로 관리
   variant?: ButtonVariant;
-  // size는 화면 크기가 아니라 사용 맥락(모달/폼/랜딩 CTA 등)에 맞춰 호출부가 명시적으로 sm/md지정
+  // size는 화면 크기가 아니라 사용 맥락(모달/폼/랜딩 CTA 등)에 맞춰 호출부가 명시적으로 지정
+  // - xs: 높이 44px, radius 12px, 폰트 18px (헤더/GNB 로그인 버튼 등 좁은 공간용, Figma 로그인 버튼 기준)
+  // - sm: 높이 54px, radius 12px, 폰트 16px, 아이콘 간격 4px (Figma 모바일 프레임 기준)
+  // - md: 높이 60px, radius 16px, 폰트 18px, 아이콘 간격 8px (Figma 태블릿/PC 프레임 기준)
   size?: ButtonSize;
   // 라벨 뒤에 붙는 아이콘 — 없으면 텍스트만 있는 버튼
   icon?: ReactNode;
   children: ReactNode;
 }
+
+// 사이즈별 높이/라운드/폰트/아이콘 간격 — 브레이크포인트가 아니라 호출부가 맥락에 맞춰 직접 고르는 값
+const SIZE_STYLE: Record<ButtonSize, string> = {
+  xs: "text-18 h-11 gap-1 rounded-xl",
+  sm: "text-16 h-[54px] gap-1 rounded-xl",
+  md: "text-18 h-[60px] gap-2 rounded-2xl",
+};
 
 // 버튼은 항상 w-full(부모 폭에 꽉 참) — 부모가 폭을 제어해야 함
 // - 화면 전체 폭 CTA로 쓰려면 부모에 padding만 주고 별도 width 지정 X
@@ -33,7 +43,7 @@ export default function Button({
       type={type}
       className={clsx(
         "flex w-full items-center justify-center px-4 font-semibold transition-colors",
-        size === "sm" ? "text-16 h-[54px] gap-1 rounded-xl" : "text-18 h-[60px] gap-2 rounded-2xl",
+        SIZE_STYLE[size],
         variant === "solid"
           ? "bg-orange-400 text-white not-disabled:hover:bg-orange-500 disabled:cursor-not-allowed disabled:bg-gray-300"
           : "border border-orange-400 bg-gray-50 text-orange-400 shadow-[4px_4px_10px_0px_rgba(195,217,242,0.2)] not-disabled:hover:bg-orange-100 disabled:cursor-not-allowed disabled:border-gray-400 disabled:text-gray-500",


### PR DESCRIPTION
## 📌 개요

- Button 컴포넌트가 sm/md 두 사이즈만 지원해 헤더/GNB의 로그인 버튼과 같은 작은 사이즈가 필요한 곳에서 재사용이 안되는 문제를 해결

## 🔢 Linked Issue

- close #43 

## 🛠️ 주요 변경 사항

- Button에 xs 사이즈 추가 (높이 44px, radius 12px, 폰트 18px — Figma 로그인 버튼 기준)
- 사이즈별 스타일을 SIZE_STYLE 객체로 정리해서 사이즈 추가/관리 용이하게 리팩토링
- 컴포넌트 테스트 페이지(/component-button)에 xs 예시(default/disabled) 추가

## 📸 스크린샷 (선택)

## 🧪 테스트 결과 & 리뷰 요청 사항

- /component-button 페이지에서 xs 사이즈(로그인 버튼 폭 기준 w-[116px]로 감싼 예시)로 default/disabled 상태 확인했습니다.

## 📋 완료 체크리스트

- [x] 브랜치 방향(To dev)을 올바르게 설정했나요?
- [x] 무관한 파일이나 테스트용 코드가 커밋에 포함되지 않았나요?
- [x] (`npm run dev`) 시 에러가 발생하지 않나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 로그인 버튼에 사용할 수 있는 `xs` 크기 버튼을 추가했습니다.
  - 일반 상태와 비활성화 상태의 `xs` 버튼 예시를 제공합니다.
  - `xs` 버튼은 44px 높이와 18px 글꼴 크기로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->