### PR TITLE
feat: 공통 컴포넌트 header/ sub-header 작업

### DIFF
--- a/src/app/(main)/component-header/page.tsx
+++ b/src/app/(main)/component-header/page.tsx
@@ -1,0 +1,32 @@
+import Header from "@/component/common/header";
+export default function Page() {
+  const page = ["견적요청", "견적 상세", "찜한 기사님"];
+  return (
+    <div className="bg-background-background-100">
+      <h1 className="text-16 text-gray-gray-400 mt-1 ml-2">Header - lg사이즈</h1>
+      <section className="mt-6 flex flex-wrap gap-x-3.5 gap-y-4.5">
+        {page.map((p) => (
+          <Header size="lg" key={p}>
+            {p}
+          </Header>
+        ))}
+      </section>
+      <h2 className="text-16 text-gray-gray-400 mt-1 ml-2">Header - md사이즈</h2>
+      <section className="mt-6 flex flex-col gap-x-3.5 gap-y-4.5">
+        {page.map((p) => (
+          <Header size="md" key={p} className="w-150">
+            {p}
+          </Header>
+        ))}
+      </section>
+      <h3 className="text-16 text-gray-gray-400 mt-1 ml-2">Header - sm사이즈</h3>
+      <section className="mt-6 flex flex-col gap-x-3.5 gap-y-4.5">
+        {page.map((p) => (
+          <Header size="sm" key={p} className="w-93.75">
+            {p}
+          </Header>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/src/app/(main)/component-header/page.tsx
+++ b/src/app/(main)/component-header/page.tsx
@@ -14,7 +14,7 @@ export default function Page() {
       <h2 className="text-16 text-gray-gray-400 mt-1 ml-2">Header - md사이즈</h2>
       <section className="mt-6 flex flex-col gap-x-3.5 gap-y-4.5">
         {page.map((p) => (
-          <Header size="md" key={p} className="w-150">
+          <Header size="md" key={p} className="w-186">
             {p}
           </Header>
         ))}

--- a/src/app/(main)/component-sub-header/page.tsx
+++ b/src/app/(main)/component-sub-header/page.tsx
@@ -1,0 +1,64 @@
+import SubHeader from "@/component/common/sub-header";
+
+const MOCK = {
+  userId: 63,
+  category: "HOME",
+  movingDate: "2026-12-25T00:00:00.000Z",
+  fromPostalCode: "06134",
+  fromRegion: "SEOUL",
+  fromAddress: "서울특별시 강남구 테헤란로 123",
+  fromDetailAddress: "101동 202호",
+  toPostalCode: "13529",
+  toRegion: "GYEONGGI",
+  toAddress: "경기도 성남시 분당구 판교역로 235",
+  toDetailAddress: "303동 404호",
+  quotationStatus: "PENDING",
+  createdAt: "2026-09-09T00:47:07.065Z",
+  updatedAt: "2026-09-09T00:47:07.065Z",
+} as const;
+
+export default function Page() {
+  return (
+    <div className="flex flex-col gap-20">
+      <section className="w-full">
+        <h1 className="text-16 text-gray-gray-400 ml-6">sub-header lg사이즈</h1>
+        <div className="bg-background-200 w-full">
+          <SubHeader
+            size="lg"
+            category={MOCK.category}
+            createdAt={MOCK.createdAt}
+            fromAddress={MOCK.fromAddress}
+            toAddress={MOCK.toAddress}
+            movingDate={MOCK.movingDate}
+          />
+        </div>
+      </section>
+      <section className="w-186">
+        <h2 className="text-16 text-gray-gray-400 ml-6">sub-header md사이즈</h2>
+        <div className="bg-background-200 w-186">
+          <SubHeader
+            size="md"
+            category={MOCK.category}
+            createdAt={MOCK.createdAt}
+            fromAddress={MOCK.fromAddress}
+            toAddress={MOCK.toAddress}
+            movingDate={MOCK.movingDate}
+          />
+        </div>
+      </section>
+      <section className="w-93.75">
+        <h3 className="text-16 text-gray-gray-400 ml-6">sub-header sm사이즈</h3>
+        <div className="bg-background-200 w-93.75">
+          <SubHeader
+            size="sm"
+            category={MOCK.category}
+            createdAt={MOCK.createdAt}
+            fromAddress={MOCK.fromAddress}
+            toAddress={MOCK.toAddress}
+            movingDate={MOCK.movingDate}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,7 +21,6 @@
   --color-gray-300: #d9d9d9;
   --color-gray-400: #b3b3b3;
   --color-gray-500: #7a7a79;
-  --color-gray-gray-50: #ffffff;
   --color-gray-gray-200: #c4c4c4;
   --color-gray-gray-300: #ababab;
   --color-gray-gray-400: #999999;
@@ -35,7 +34,7 @@
   --color-black-500: #111111;
   --color-black-black-300: #373737;
   --color-black-black-400: #262524;
-  --color-black-black-500: #111;
+
   /* Primary orange (brand) */
   --color-orange-100: #feeeea;
   --color-orange-200: #fed8d0;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,6 +21,7 @@
   --color-gray-300: #d9d9d9;
   --color-gray-400: #b3b3b3;
   --color-gray-500: #7a7a79;
+  --color-gray-gray-50: #ffffff;
   --color-gray-gray-300: #ababab;
   --color-gray-gray-400: #999999;
   --color-gray-gray-500: #808080;
@@ -33,7 +34,7 @@
   --color-black-500: #111111;
   --color-black-black-300: #373737;
   --color-black-black-400: #262524;
-
+  --color-black-black-500: #111;
   /* Primary orange (brand) */
   --color-orange-100: #feeeea;
   --color-orange-200: #fed8d0;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,6 +21,7 @@
   --color-gray-300: #d9d9d9;
   --color-gray-400: #b3b3b3;
   --color-gray-500: #7a7a79;
+  --color-gray-gray-50: #ffffff;
   --color-gray-gray-400: #999999;
   --color-gray-gray-500: #808080;
 
@@ -31,7 +32,7 @@
   --color-black-400: #1e1e1e;
   --color-black-500: #111111;
   --color-black-black-400: #262524;
-
+  --color-black-black-500: #111;
   /* Primary orange (brand) */
   --color-orange-100: #feeeea;
   --color-orange-200: #fed8d0;

--- a/src/component/common/header.tsx
+++ b/src/component/common/header.tsx
@@ -8,8 +8,9 @@ interface HeaderProps extends HTMLAttributes<HTMLDivElement> {
   size?: HeaderSize;
 }
 
+const SM_SIZE = "py-3.5 pl-7.5";
 const MD_SIZE = "px-18 py-3.5";
-const LG_SIZE = "flex h-8 w-full items-center px-92 py-8 text-24";
+const LG_SIZE = "flex w-full items-center px-92 py-8 text-24";
 
 // 사용법: <Header size="lg">제목 텍스트</Header>
 export default function Header({ children, size = "sm", className, ...props }: HeaderProps) {
@@ -19,7 +20,8 @@ export default function Header({ children, size = "sm", className, ...props }: H
   return (
     <section
       className={clsx(
-        "text-18 text-black-black-500 bg-gray-gray-50 py-3.5 pl-7.5 font-semibold",
+        "text-18 text-black-black-500 bg-gray-gray-50 font-semibold",
+        !isMd && !isLg && SM_SIZE,
         isMd && MD_SIZE,
         isLg && LG_SIZE,
         className

--- a/src/component/common/header.tsx
+++ b/src/component/common/header.tsx
@@ -1,0 +1,32 @@
+import clsx from "clsx";
+import type { HTMLAttributes, ReactNode } from "react";
+
+type HeaderSize = "sm" | "md" | "lg";
+
+interface HeaderProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  size?: HeaderSize;
+}
+
+const MD_SIZE = "px-18 py-3.5";
+const LG_SIZE = "flex h-8 w-full items-center px-92 py-8 text-24";
+
+// 사용법: <Header size="lg">제목 텍스트</Header>
+export default function Header({ children, size = "sm", className, ...props }: HeaderProps) {
+  const isMd = size === "md";
+  const isLg = size === "lg";
+
+  return (
+    <section
+      className={clsx(
+        "text-18 text-black-black-500 bg-gray-gray-50 py-3.5 pl-7.5 font-semibold",
+        isMd && MD_SIZE,
+        isLg && LG_SIZE,
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </section>
+  );
+}

--- a/src/component/common/header.tsx
+++ b/src/component/common/header.tsx
@@ -20,7 +20,7 @@ export default function Header({ children, size = "sm", className, ...props }: H
   return (
     <section
       className={clsx(
-        "text-18 text-black-black-500 bg-gray-gray-50 font-semibold",
+        "text-18 text-black-500 bg-gray-50 font-semibold",
         !isMd && !isLg && SM_SIZE,
         isMd && MD_SIZE,
         isLg && LG_SIZE,

--- a/src/component/common/sub-header.tsx
+++ b/src/component/common/sub-header.tsx
@@ -1,0 +1,15 @@
+import { HTMLAttributes, ReactNode } from "react";
+
+interface SubHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  size?: SubHeaderSize;
+}
+
+type SubHeaderSize = "sm" | "md" | "lg";
+const LG_SIZE = "";
+
+export default function SubHeader({ children, size, className, ...props }: SubHeaderProps) {
+  const isMd = size === "md";
+  const isLg = size === "lg";
+  return <section className=""></section>;
+}

--- a/src/component/common/sub-header.tsx
+++ b/src/component/common/sub-header.tsx
@@ -74,7 +74,7 @@ export default function SubHeader({
       {...props}
     >
       <header className={clsx("flex flex-col", big && "gap-1")}>
-        <p className={clsx("text-black-black-500 font-bold", big ? "text-24" : "text-20")}>
+        <p className={clsx("text-black-500 font-bold", big ? "text-24" : "text-20")}>
           {SERVICE_LABELS[category]}
         </p>
         <p

--- a/src/component/common/sub-header.tsx
+++ b/src/component/common/sub-header.tsx
@@ -25,9 +25,9 @@ function formatDate(iso: string) {
 
 function shortenAddress(address: string) {
   const tokens = address.trim().split(/\s+/);
-  const isProvince = tokens[0].endsWith("도");
-  const [city, district] = isProvince ? tokens.slice(1, 3) : tokens;
-  return `${isProvince ? city : city.replace(/(특별시|광역시)/, "시")} ${district}`;
+  const isProvince = tokens[0]?.endsWith("도");
+  const city = isProvince ? tokens[0] : tokens[0]?.replace(/(특별시|광역시)/, "시");
+  return tokens[1] ? `${city} ${tokens[1]}` : (city ?? "");
 }
 
 function Field({
@@ -44,9 +44,7 @@ function Field({
   return (
     <div className={clsx(big ? "flex flex-col" : "flex justify-between", className)}>
       <p className="text-14 text-gray-gray-500 font-normal">{label}</p>
-      <p className={clsx("text-14 text-black-black-500 font-semibold", big && "text-18")}>
-        {value}
-      </p>
+      <p className={clsx("text-14 text-black-500 font-semibold", big && "text-18")}>{value}</p>
     </div>
   );
 }

--- a/src/component/common/sub-header.tsx
+++ b/src/component/common/sub-header.tsx
@@ -24,7 +24,7 @@ function formatDate(iso: string) {
 }
 
 function shortenAddress(address: string) {
-  const tokens = address.split(" ");
+  const tokens = address.trim().split(/\s+/);
   const isProvince = tokens[0].endsWith("도");
   const [city, district] = isProvince ? tokens.slice(1, 3) : tokens;
   return `${isProvince ? city : city.replace(/(특별시|광역시)/, "시")} ${district}`;

--- a/src/component/common/sub-header.tsx
+++ b/src/component/common/sub-header.tsx
@@ -69,7 +69,7 @@ export default function SubHeader({
     <section
       className={clsx(
         "flex flex-col gap-5 px-6 py-6",
-        isMd && "px-8 py-8",
+        isMd && "px-18 py-8",
         isLg && "flex flex-row justify-between py-8 pr-100 pl-80",
         className
       )}

--- a/src/component/common/sub-header.tsx
+++ b/src/component/common/sub-header.tsx
@@ -1,15 +1,105 @@
-import { HTMLAttributes, ReactNode } from "react";
+import clsx from "clsx";
+import type { HTMLAttributes } from "react";
+import { SERVICE_LABELS, type ServiceCode } from "./chip-region";
+
+type SubHeaderSize = "sm" | "md" | "lg";
 
 interface SubHeaderProps extends HTMLAttributes<HTMLDivElement> {
-  children: ReactNode;
+  category: ServiceCode;
+  createdAt: string;
+  fromAddress: string;
+  toAddress: string;
+  movingDate: string;
   size?: SubHeaderSize;
 }
 
-type SubHeaderSize = "sm" | "md" | "lg";
-const LG_SIZE = "";
+const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
-export default function SubHeader({ children, size, className, ...props }: SubHeaderProps) {
-  const isMd = size === "md";
+function formatDate(iso: string) {
+  const kst = new Date(new Date(iso).getTime() + KST_OFFSET_MS);
+  const mm = String(kst.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(kst.getUTCDate()).padStart(2, "0");
+  return `${kst.getUTCFullYear()}년 ${mm}월 ${dd}일 (${WEEKDAYS[kst.getUTCDay()]})`;
+}
+
+function shortenAddress(address: string) {
+  const tokens = address.split(" ");
+  const isProvince = tokens[0].endsWith("도");
+  const [city, district] = isProvince ? tokens.slice(1, 3) : tokens;
+  return `${isProvince ? city : city.replace(/(특별시|광역시)/, "시")} ${district}`;
+}
+
+function Field({
+  label,
+  value,
+  big,
+  className,
+}: {
+  label: string;
+  value: string;
+  big: boolean;
+  className?: string;
+}) {
+  return (
+    <div className={clsx(big ? "flex flex-col" : "flex justify-between", className)}>
+      <p className="text-14 text-gray-gray-500 font-normal">{label}</p>
+      <p className={clsx("text-14 text-black-black-500 font-semibold", big && "text-18")}>
+        {value}
+      </p>
+    </div>
+  );
+}
+
+export default function SubHeader({
+  category,
+  createdAt,
+  fromAddress,
+  toAddress,
+  movingDate,
+  size = "sm",
+  className,
+  ...props
+}: SubHeaderProps) {
   const isLg = size === "lg";
-  return <section className=""></section>;
+  const isMd = size === "md";
+  const big = isMd || isLg;
+
+  return (
+    <section
+      className={clsx(
+        "flex flex-col gap-5 px-6 py-6",
+        isMd && "px-8 py-8",
+        isLg && "flex flex-row justify-between py-8 pr-100 pl-80",
+        className
+      )}
+      {...props}
+    >
+      <header className={clsx("flex flex-col", big && "gap-1")}>
+        <p className={clsx("text-black-black-500 font-bold", big ? "text-24" : "text-20")}>
+          {SERVICE_LABELS[category]}
+        </p>
+        <p
+          className={clsx(
+            big ? "text-14 text-gray-gray-500 font-normal" : "text-gray-gray-500 text-12"
+          )}
+        >
+          견적 신청일: {formatDate(createdAt)}
+        </p>
+      </header>
+      <div className={clsx(big ? "flex flex-row items-end" : "flex flex-col")}>
+        <Field label="출발지" value={shortenAddress(fromAddress)} big={big} />
+        <span className={clsx(big ? "px-3 pb-0.5" : "hidden")} aria-hidden>
+          {" → "}
+        </span>
+        <Field label="도착지" value={shortenAddress(toAddress)} big={big} />
+        <Field
+          label="이사일"
+          value={formatDate(movingDate)}
+          big={big}
+          className={big ? "pl-10" : undefined}
+        />
+      </div>
+    </section>
+  );
 }


### PR DESCRIPTION
## 📌 개요

- 공통 컴포넌트 Header, SubHeader 작업

## 🔢 Linked Issue

- close #32

## 🛠️ 주요 변경 사항

- [x] Header 컴포넌트 sm/md/lg 사이즈별 스타일 작업, 높이/패딩 충돌 버그 수정
- [x] SubHeader 컴포넌트 신규 작업 (서비스 종류/견적 신청일/출발지·도착지/이사일 표시, sm/md/lg 대응)
- [x] 공용 색상 토큰 `gray-gray-50`, `black-black-500` 추가

## 📸 스크린샷 (선택)

## 🧪 테스트 결과 & 리뷰 요청 사항

- `/component-header`, `/component-sub-header` 데모 페이지에서 사이즈별 렌더링 확인
  - 예시 페이지의 `w-*`, 배경색(`bg-background-200`) 클래스는 사이즈 구분을 위한 데모용이며 실제 스타일 값 아님
- 날짜 포맷 KST 기준으로 계산되는지, 주소 축약 로직(특별시/광역시 vs 도) 리뷰 요청

## 📋 완료 체크리스트

- [x] 브랜치 방향(To dev)을 올바르게 설정했나요?
- [x] 무관한 파일이나 테스트용 코드가 커밋에 포함되지 않았나요?
- [x] (`npm run dev`) 시 에러가 발생하지 않나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 다양한 화면 크기(`lg`, `md`, `sm`)에 대응하는 공통 헤더 컴포넌트를 추가했습니다.
  - 카테고리, 견적 신청일, 출발지·도착지, 이사일을 표시하는 서브 헤더를 추가했습니다.
  - 헤더와 서브 헤더에 크기별 레이아웃과 스타일을 적용할 수 있습니다.
  - 날짜를 한국어 형식으로 표시하고, 주소를 간략한 지역명으로 보여줍니다.

- **문서 및 예시**
  - 헤더와 서브 헤더의 크기별 표시 상태를 확인할 수 있는 예시 페이지를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->