### PR TITLE
feat: 공통 컴포넌트 progress-bar 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query-devtools": "^5.102.8",
         "clsx": "^2.1.1",
         "next": "16.3.3",
+        "next-flex-rating": "^1.0.4",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "react-hook-form": "^7.86.0"
@@ -6067,6 +6068,15 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-flex-rating": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/next-flex-rating/-/next-flex-rating-1.0.4.tgz",
+      "integrity": "sha512-Lhtxf3ZHuaqbW6IcUTKBHSTT+aRiFvqgRnxQc/u0i6MekMBRLEe4pp/NwjXgkigI0nN/0Tu3G0u+o7ogarnsEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@tanstack/react-query-devtools": "^5.102.8",
     "clsx": "^2.1.1",
     "next": "16.3.3",
+    "next-flex-rating": "^1.0.4",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-hook-form": "^7.86.0"

--- a/src/app/(main)/component-progress-bar/page.tsx
+++ b/src/app/(main)/component-progress-bar/page.tsx
@@ -1,0 +1,68 @@
+import ProgressBar from "@/component/common/progress-bar";
+
+const integerAverageData = {
+  "1": 0,
+  "2": 0,
+  "3": 0,
+  "4": 0,
+  "5": 30,
+  totalCount: 30,
+};
+
+const decimalAverageData = {
+  "1": 0,
+  "2": 0,
+  "3": 20,
+  "4": 30,
+  "5": 50,
+  totalCount: 100,
+};
+
+const lowAverageData = {
+  "1": 12,
+  "2": 8,
+  "3": 3,
+  "4": 1,
+  "5": 1,
+  totalCount: 25,
+};
+
+const noReviewData = {
+  "1": 0,
+  "2": 0,
+  "3": 0,
+  "4": 0,
+  "5": 0,
+  totalCount: 0,
+};
+
+export default function ProgressBarPage() {
+  return (
+    <div className="mt-30 flex w-full flex-col gap-16 px-20">
+      <section className="max-w-7xl">
+        <h2 className="text-14 mb-3 font-semibold text-gray-500">평균 정수 단위 (5.0)</h2>
+        <div className="bg-background-200 rounded-2xl p-6">
+          <ProgressBar data={integerAverageData} />
+        </div>
+      </section>
+      <section className="max-w-7xl">
+        <h2 className="text-14 mb-3 font-semibold text-gray-500">평균 소수점 단위 (4.3)</h2>
+        <div className="bg-background-200 rounded-2xl p-6">
+          <ProgressBar data={decimalAverageData} />
+        </div>
+      </section>
+      <section className="max-w-7xl">
+        <h2 className="text-14 mb-3 font-semibold text-gray-500">저평점 다수</h2>
+        <div className="bg-background-200 rounded-2xl p-6">
+          <ProgressBar data={lowAverageData} />
+        </div>
+      </section>
+      <section className="max-w-7xl">
+        <h2 className="text-14 mb-3 font-semibold text-gray-500">리뷰 없음 (0 나누기 방어)</h2>
+        <div className="bg-background-200 rounded-2xl p-6">
+          <ProgressBar data={noReviewData} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,6 +46,7 @@
   /* Secondary red */
   --color-red-100: #ffeef0;
   --color-red-200: #ff4f64;
+  --color-yellow-100: #ffc149;
 
   /* Background */
   --color-background-100: #fcfcfc;
@@ -64,6 +65,8 @@
   /* 타이포그래피: font-size + line-height는 한 세트로 관리, font-weight는 text-*와 조합해서 각자 커스텀 */
   --text-50: 50px;
   --text-50--line-height: 42px;
+  --text-40: 40px;
+  --text-40--line-height: normal;
   --text-32: 32px;
   --text-32--line-height: 42px;
   --text-24: 24px;

--- a/src/component/common/progress-bar.tsx
+++ b/src/component/common/progress-bar.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Image from "next/image";
+import { Rating } from "next-flex-rating";
+import starActive from "@/assets/icons/star-sm-active.svg";
+import starDefault from "@/assets/icons/star-sm-default.svg";
+
+interface ReviewDistribution {
+  "1": number;
+  "2": number;
+  "3": number;
+  "4": number;
+  "5": number;
+  totalCount: number;
+}
+
+const RATINGS = ["5", "4", "3", "2", "1"] as const;
+
+export default function ProgressBar({ data }: { data: ReviewDistribution }) {
+  const average = data.totalCount
+    ? RATINGS.reduce<number>((sum, rating) => sum + Number(rating) * data[rating], 0) /
+      data.totalCount
+    : 0;
+
+  return (
+    <>
+      <div className="text-16 tablet:text-20 pc:text-20 mb-2 font-semibold">리뷰</div>
+      <div className="tablet:flex-row tablet:justify-between flex flex-col gap-1 text-left">
+        <div className="mb-4 flex flex-col gap-2">
+          <div className="flex gap-4.5">
+            <p className="text-40 font-medium">{average.toFixed(1)}</p>
+            <div>
+              <div className="flex">
+                <Rating
+                  value={average}
+                  icon={<Image src={starActive} alt="" width={20} height={20} />}
+                  emptyIcon={<Image src={starDefault} alt="" width={20} height={20} />}
+                  size={20}
+                  readOnly
+                />
+              </div>
+              <p className="text-14 text-gray-gray-500 font-normal">{data.totalCount}개의 리뷰</p>
+            </div>
+          </div>
+        </div>
+        <div>
+          {RATINGS.map((rating) => {
+            const count = data[rating];
+            const percent = data.totalCount ? (count / data.totalCount) * 100 : 0;
+            return (
+              <section key={rating} className="flex items-center gap-4">
+                <span className="text-14 text-black-300 w-9 font-bold">{rating}점</span>
+                <div className="bg-background-300 h-2 w-45 rounded-[15px]">
+                  <div
+                    className="h-full rounded-[15px] bg-yellow-100"
+                    style={{ width: `${percent}%` }}
+                  ></div>
+                </div>
+                <span className="text-14 text-gray-gray-300 font-medium">{count}</span>
+              </section>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/component/common/progress-bar.tsx
+++ b/src/component/common/progress-bar.tsx
@@ -43,7 +43,7 @@ export default function ProgressBar({ data }: { data: ReviewDistribution }) {
             </div>
           </div>
         </div>
-        <div>
+        <div className="flex flex-col gap-1">
           {RATINGS.map((rating) => {
             const count = data[rating];
             const percent = data.totalCount ? (count / data.totalCount) * 100 : 0;


### PR DESCRIPTION
## 📌 개요

- 리뷰 평점/분포 표시하는 공통 컴포넌트 `ProgressBar` 작업

## 🔢 Linked Issue

- close #

## 🛠️ 주요 변경 사항

- [x] `ProgressBar` 컴포넌트 신규 작업 (평균 별점 + 별점별 분포 막대 표시)
- [x] `next-flex-rating` 라이브러리로 별점 표시 (소수점 단위 fractional fill 지원)
- [x] 커스텀 별 아이콘(`star-sm-active`/`star-sm-default`) 적용
- [x] 공용 토큰 `--color-yellow-100`, `--text-40` 추가
- [x] 확인 페이지에 정수/소수점/저평점/리뷰없음 4가지 케이스 데모 추가

## 📸 스크린샷 (선택)

## 🧪 테스트 결과 & 리뷰 요청 사항

- `/component-progress-bar`에서 케이스별 렌더링 확인
- 현재 별점당 조회하는 API가 미구현 상태라, 추가될 예정인 응답 형식을 기준으로 mock 데이터를 넣어뒀습니다. API 연동 시 `data` prop에 응답 그대로 넘기면 되는 구조입니다.
- 추가 필요한 데이터 형식 담당자이신 @MunChiho 님께 전달드렸습니다!

## 📋 완료 체크리스트

- [x] 브랜치 방향(To dev)을 올바르게 설정했나요?
- [x] 무관한 파일이나 테스트용 코드가 커밋에 포함되지 않았나요?
- [x] (`npm run dev`) 시 에러가 발생하지 않나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 리뷰 평점별 분포와 비율을 시각적으로 보여주는 프로그레스 바를 추가했습니다.
  - 평균 평점과 별점을 함께 표시하며, 리뷰가 없는 경우에도 안정적으로 표시됩니다.
  - 정수·소수 평균, 저평점 리뷰 다수 등 다양한 평점 분포를 확인할 수 있는 데모 페이지를 추가했습니다.

- **스타일**
  - 평점 UI에 사용할 노란색 색상과 40px 텍스트 스타일을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->