### PR TITLE
feat: 공통 컴포넌트 Modal / Pop-up 작업

### DIFF
--- a/src/app/(main)/component-modal-popup/page.tsx
+++ b/src/app/(main)/component-modal-popup/page.tsx
@@ -13,8 +13,14 @@ import Toast from "@/component/common/toast";
 import type { ServiceCode } from "@/component/common/chip-region";
 
 const MOCK_RESULTS: AddressSelectResult[] = [
-  { zipCode: "04538", roadAddress: "서울 중구 세종대로 110", lotAddress: "서울 중구 태평로1가 31" },
   {
+    id: "04538-세종대로-110",
+    zipCode: "04538",
+    roadAddress: "서울 중구 세종대로 110",
+    lotAddress: "서울 중구 태평로1가 31",
+  },
+  {
+    id: "13529-판교역로-235",
     zipCode: "13529",
     roadAddress: "경기 성남시 분당구 판교역로 235",
     lotAddress: "경기 성남시 분당구 삼평동 683",
@@ -36,10 +42,10 @@ type ModalKey =
 
 export default function Page() {
   const [openModal, setOpenModal] = useState<ModalKey | null>(null);
-  const [showToast, setShowToast] = useState(false);
+  const [toastToken, setToastToken] = useState<number | null>(null);
 
   const [searchValue, setSearchValue] = useState("");
-  const [selectedZipCode, setSelectedZipCode] = useState<string>();
+  const [selectedId, setSelectedId] = useState<string>();
 
   const [category] = useState<ServiceCode>("SMALL");
   const [price, setPrice] = useState("");
@@ -54,10 +60,10 @@ export default function Page() {
   const [review, setReview] = useState("");
 
   useEffect(() => {
-    if (!showToast) return;
-    const timer = setTimeout(() => setShowToast(false), 2000);
+    if (toastToken == null) return;
+    const timer = setTimeout(() => setToastToken(null), 2000);
     return () => clearTimeout(timer);
-  }, [showToast]);
+  }, [toastToken]);
 
   const close = () => setOpenModal(null);
 
@@ -118,7 +124,7 @@ export default function Page() {
 
       <h3 className="text-16 text-gray-gray-400">토스트 팝업</h3>
       <section className="flex gap-3">
-        <Button size="sm" className="w-40" onClick={() => setShowToast(true)}>
+        <Button size="sm" className="w-40" onClick={() => setToastToken(Date.now())}>
           toast 띄우기
         </Button>
       </section>
@@ -128,10 +134,13 @@ export default function Page() {
         onClose={close}
         size={openModal === "address-sm" ? "sm" : "md"}
         searchValue={searchValue}
-        onSearchChange={setSearchValue}
+        onSearchChange={(value) => {
+          setSearchValue(value);
+          setSelectedId(undefined);
+        }}
         results={searchValue ? MOCK_RESULTS : []}
-        selectedZipCode={selectedZipCode}
-        onSelect={(result) => setSelectedZipCode(result.zipCode)}
+        selectedId={selectedId}
+        onSelect={(result) => setSelectedId(result.id)}
         onConfirm={close}
       />
 
@@ -202,7 +211,7 @@ export default function Page() {
         onSubmit={close}
       />
 
-      {showToast && <Toast message="링크가 복사되었어요" />}
+      {toastToken != null && <Toast message="링크가 복사되었어요" />}
     </div>
   );
 }

--- a/src/app/(main)/component-modal-popup/page.tsx
+++ b/src/app/(main)/component-modal-popup/page.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Button from "@/component/common/button";
+import AddressSelectModal, {
+  type AddressSelectResult,
+} from "@/component/common/address-select-modal";
+import FilterModal from "@/component/common/filter-modal";
+import InfoRequiredModal from "@/component/common/info-required-modal";
+import QuoteActionModal from "@/component/common/quote-action-modal";
+import ReviewWriteModal from "@/component/common/review-write-modal";
+import Toast from "@/component/common/toast";
+import type { ServiceCode } from "@/component/common/chip-region";
+
+const MOCK_RESULTS: AddressSelectResult[] = [
+  { zipCode: "04538", roadAddress: "서울 중구 세종대로 110", lotAddress: "서울 중구 태평로1가 31" },
+  {
+    zipCode: "13529",
+    roadAddress: "경기 성남시 분당구 판교역로 235",
+    lotAddress: "경기 성남시 분당구 삼평동 683",
+  },
+];
+
+type ModalKey =
+  | "address-sm"
+  | "address-md"
+  | "send-sm"
+  | "send-md"
+  | "reject-sm"
+  | "reject-md"
+  | "info-sm"
+  | "info-md"
+  | "filter"
+  | "review-sm"
+  | "review-md";
+
+export default function Page() {
+  const [openModal, setOpenModal] = useState<ModalKey | null>(null);
+  const [showToast, setShowToast] = useState(false);
+
+  const [searchValue, setSearchValue] = useState("");
+  const [selectedZipCode, setSelectedZipCode] = useState<string>();
+
+  const [category] = useState<ServiceCode>("SMALL");
+  const [price, setPrice] = useState("");
+  const [comment, setComment] = useState("");
+  const [reason, setReason] = useState("");
+
+  const [moveType, setMoveType] = useState<ServiceCode>();
+  const [isTargetedOnly, setIsTargetedOnly] = useState(false);
+  const [isServiceAreaOnly, setIsServiceAreaOnly] = useState(false);
+
+  const [rating, setRating] = useState(0);
+  const [review, setReview] = useState("");
+
+  useEffect(() => {
+    if (!showToast) return;
+    const timer = setTimeout(() => setShowToast(false), 2000);
+    return () => clearTimeout(timer);
+  }, [showToast]);
+
+  const close = () => setOpenModal(null);
+
+  return (
+    <div className="bg-background-background-100 flex flex-col gap-4 p-6">
+      <h1 className="text-16 text-gray-gray-400">배송지 선택 모달</h1>
+      <section className="flex gap-3">
+        <Button size="sm" className="w-40" onClick={() => setOpenModal("address-sm")}>
+          address · sm
+        </Button>
+        <Button size="sm" className="w-40" onClick={() => setOpenModal("address-md")}>
+          address · md
+        </Button>
+      </section>
+
+      <h2 className="text-16 text-gray-gray-400">견적 보내기 / 반려요청 모달</h2>
+      <section className="flex flex-wrap gap-3">
+        <Button size="sm" className="w-40" onClick={() => setOpenModal("send-sm")}>
+          견적보내기 · sm
+        </Button>
+        <Button size="sm" className="w-40" onClick={() => setOpenModal("send-md")}>
+          견적보내기 · md
+        </Button>
+        <Button size="sm" className="w-40" onClick={() => setOpenModal("reject-sm")}>
+          반려요청 · sm
+        </Button>
+        <Button size="sm" className="w-40" onClick={() => setOpenModal("reject-md")}>
+          반려요청 · md
+        </Button>
+      </section>
+
+      <h3 className="text-16 text-gray-gray-400">일반 요청 필요 모달</h3>
+      <section className="flex gap-3">
+        <Button size="sm" className="w-40" onClick={() => setOpenModal("info-sm")}>
+          info · sm
+        </Button>
+        <Button size="sm" className="w-40" onClick={() => setOpenModal("info-md")}>
+          info · md
+        </Button>
+      </section>
+
+      <h3 className="text-16 text-gray-gray-400">필터 바텀시트</h3>
+      <section className="flex gap-3">
+        <Button size="sm" className="w-40" onClick={() => setOpenModal("filter")}>
+          filter
+        </Button>
+      </section>
+
+      <h3 className="text-16 text-gray-gray-400">리뷰 쓰기 모달</h3>
+      <section className="flex gap-3">
+        <Button size="sm" className="w-40" onClick={() => setOpenModal("review-sm")}>
+          review · sm
+        </Button>
+        <Button size="sm" className="w-40" onClick={() => setOpenModal("review-md")}>
+          review · md
+        </Button>
+      </section>
+
+      <h3 className="text-16 text-gray-gray-400">토스트 팝업</h3>
+      <section className="flex gap-3">
+        <Button size="sm" className="w-40" onClick={() => setShowToast(true)}>
+          toast 띄우기
+        </Button>
+      </section>
+
+      <AddressSelectModal
+        open={openModal === "address-sm" || openModal === "address-md"}
+        onClose={close}
+        size={openModal === "address-sm" ? "sm" : "md"}
+        searchValue={searchValue}
+        onSearchChange={setSearchValue}
+        results={searchValue ? MOCK_RESULTS : []}
+        selectedZipCode={selectedZipCode}
+        onSelect={(result) => setSelectedZipCode(result.zipCode)}
+        onConfirm={close}
+      />
+
+      <QuoteActionModal
+        open={openModal === "send-sm" || openModal === "send-md"}
+        onClose={close}
+        variant="send"
+        size={openModal === "send-sm" ? "sm" : "md"}
+        category={category}
+        customerName="김인서"
+        fromAddress="서울시 중구"
+        toAddress="경기도 수원시"
+        movingDate="2024.07.01 (월)"
+        price={price}
+        onPriceChange={setPrice}
+        comment={comment}
+        onCommentChange={setComment}
+        onSubmit={close}
+      />
+
+      <QuoteActionModal
+        open={openModal === "reject-sm" || openModal === "reject-md"}
+        onClose={close}
+        variant="reject"
+        size={openModal === "reject-sm" ? "sm" : "md"}
+        category={category}
+        customerName="김인서"
+        fromAddress="서울시 중구"
+        toAddress="경기도 수원시"
+        movingDate="2024.07.01 (월)"
+        reason={reason}
+        onReasonChange={setReason}
+        onSubmit={close}
+      />
+
+      <InfoRequiredModal
+        open={openModal === "info-sm" || openModal === "info-md"}
+        onClose={close}
+        size={openModal === "info-sm" ? "sm" : "md"}
+        onAction={close}
+      />
+
+      <FilterModal
+        open={openModal === "filter"}
+        onClose={close}
+        moveType={moveType}
+        onMoveTypeChange={setMoveType}
+        isTargetedOnly={isTargetedOnly}
+        onTargetedOnlyChange={setIsTargetedOnly}
+        isServiceAreaOnly={isServiceAreaOnly}
+        onServiceAreaOnlyChange={setIsServiceAreaOnly}
+        onApply={close}
+      />
+
+      <ReviewWriteModal
+        open={openModal === "review-sm" || openModal === "review-md"}
+        onClose={close}
+        size={openModal === "review-sm" ? "sm" : "md"}
+        category={category}
+        moverNickName="김코드"
+        fromAddress="서울시 중구"
+        toAddress="경기도 수원시"
+        movingDate="2024.07.01 (월)"
+        rating={rating}
+        onRatingChange={setRating}
+        review={review}
+        onReviewChange={setReview}
+        onSubmit={close}
+      />
+
+      {showToast && <Toast message="링크가 복사되었어요" />}
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -60,6 +60,11 @@
   /* Overlay — Card-list 반려/이사완료 카드를 덮는 딤 처리 */
   --color-overlay-dim: rgba(4, 4, 4, 0.64);
 
+  /* 모달·토스트 패널 그림자 */
+  --shadow-modal: 4px 4px 5px 0px rgba(169, 169, 169, 0.2);
+  /* 주소 카드 그림자 */
+  --shadow-address-card: 2px 2px 5px 0px rgba(224, 224, 224, 0.2);
+
   /* Line */
   --color-line-100: #f2f2f2;
   --color-line-200: var(--color-gray-200);
@@ -71,8 +76,12 @@
   /* Z-index */
   --z-gnb: 1000;
   --z-gnb-dropdown: 1010;
+  --z-modal: 1100;
+  --z-toast: 1200;
   --z-filter-dropdown: 100;
   --z-datepicker: 100;
+  --z-index-modal: var(--z-modal);
+  --z-index-toast: var(--z-toast);
 
   /* 타이포그래피: font-size + line-height는 한 세트로 관리, font-weight는 text-*와 조합해서 각자 커스텀 */
   --text-50: 50px;

--- a/src/assets/icons/x-sm.svg
+++ b/src/assets/icons/x-sm.svg
@@ -1,0 +1,6 @@
+<svg preserveAspectRatio="none" overflow="visible" style="display: block;" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="ic/X/sm">
+<path id="Vector 603" d="M16 8L8 16" stroke="#999999" stroke-width="1.5" stroke-linecap="round"/>
+<path id="Vector 605" d="M8 8L16 16" stroke="#999999" stroke-width="1.5" stroke-linecap="round"/>
+</g>
+</svg>

--- a/src/component/common/address-card.tsx
+++ b/src/component/common/address-card.tsx
@@ -1,0 +1,57 @@
+import clsx from "clsx";
+import type { ButtonHTMLAttributes } from "react";
+import AddressChip from "@/component/common/chip-address";
+
+type AddressCardSize = "sm" | "md";
+
+interface AddressCardProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "type"> {
+  zipCode: string;
+  roadAddress: string;
+  lotAddress: string;
+  size?: AddressCardSize;
+  selected?: boolean;
+}
+
+// 주소 검색 결과 카드 (도로명/지번)
+export default function AddressCard({
+  zipCode,
+  roadAddress,
+  lotAddress,
+  size = "md",
+  selected = false,
+  className,
+  ...props
+}: AddressCardProps) {
+  const isMd = size === "md";
+
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      className={clsx(
+        "shadow-address-card flex w-full flex-col items-start gap-4 rounded-2xl border px-4 pt-5 pb-6 text-left transition-colors",
+        selected ? "border-orange-500 bg-orange-100" : "border-line-100 bg-gray-50",
+        className
+      )}
+      {...props}
+    >
+      <p className={clsx("text-black-black-400 font-semibold", isMd ? "text-16" : "text-14")}>
+        {zipCode}
+      </p>
+      <div className="flex w-full flex-col items-start gap-4">
+        <div className="flex w-full items-center gap-2">
+          <AddressChip size={isMd ? "md" : "sm"}>도로명</AddressChip>
+          <p className={clsx("text-black-black-400 min-w-0 flex-1", isMd ? "text-16" : "text-14")}>
+            {roadAddress}
+          </p>
+        </div>
+        <div className="flex w-full items-center gap-2">
+          <AddressChip size={isMd ? "md" : "sm"}>지번</AddressChip>
+          <p className={clsx("text-black-black-400 min-w-0 flex-1", isMd ? "text-16" : "text-14")}>
+            {lotAddress}
+          </p>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/src/component/common/address-select-modal.tsx
+++ b/src/component/common/address-select-modal.tsx
@@ -10,6 +10,8 @@ import Modal, { ModalHeader } from "@/component/common/modal";
 type AddressSelectModalSize = "sm" | "md";
 
 export interface AddressSelectResult {
+  // zipCode는 우편번호라 같은 값이 여러 건일 수 있음 — 선택/key는 id 사용
+  id: string;
   zipCode: string;
   roadAddress: string;
   lotAddress: string;
@@ -24,7 +26,7 @@ interface AddressSelectModalProps {
   onSearchChange: (value: string) => void;
   onSearch?: (value: string) => void;
   results: AddressSelectResult[];
-  selectedZipCode?: string;
+  selectedId?: string;
   onSelect: (result: AddressSelectResult) => void;
   onConfirm: () => void;
 }
@@ -39,13 +41,13 @@ export default function AddressSelectModal({
   onSearchChange,
   onSearch,
   results,
-  selectedZipCode,
+  selectedId,
   onSelect,
   onConfirm,
 }: AddressSelectModalProps) {
   const titleId = useId();
   const isMd = size === "md";
-  const canConfirm = Boolean(selectedZipCode);
+  const canConfirm = results.some((result) => result.id === selectedId);
 
   return (
     <Modal
@@ -72,12 +74,12 @@ export default function AddressSelectModal({
           <div className="flex w-full flex-col gap-4">
             {results.map((result) => (
               <AddressCard
-                key={result.zipCode}
+                key={result.id}
                 size={size}
                 zipCode={result.zipCode}
                 roadAddress={result.roadAddress}
                 lotAddress={result.lotAddress}
-                selected={result.zipCode === selectedZipCode}
+                selected={result.id === selectedId}
                 onClick={() => onSelect(result)}
               />
             ))}

--- a/src/component/common/address-select-modal.tsx
+++ b/src/component/common/address-select-modal.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import clsx from "clsx";
+import { useId } from "react";
+import AddressCard from "@/component/common/address-card";
+import Button from "@/component/common/button";
+import InputSearchbar from "@/component/common/input-searchbar";
+import Modal, { ModalHeader } from "@/component/common/modal";
+
+type AddressSelectModalSize = "sm" | "md";
+
+export interface AddressSelectResult {
+  zipCode: string;
+  roadAddress: string;
+  lotAddress: string;
+}
+
+interface AddressSelectModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  size?: AddressSelectModalSize;
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  onSearch?: (value: string) => void;
+  results: AddressSelectResult[];
+  selectedZipCode?: string;
+  onSelect: (result: AddressSelectResult) => void;
+  onConfirm: () => void;
+}
+
+// 출발지/도착지 주소 선택 모달
+export default function AddressSelectModal({
+  open,
+  onClose,
+  title = "출발지를 선택해주세요",
+  size = "md",
+  searchValue,
+  onSearchChange,
+  onSearch,
+  results,
+  selectedZipCode,
+  onSelect,
+  onConfirm,
+}: AddressSelectModalProps) {
+  const titleId = useId();
+  const isMd = size === "md";
+  const canConfirm = Boolean(selectedZipCode);
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      labelledBy={titleId}
+      className={clsx(
+        isMd
+          ? "w-140 min-w-140 gap-10 rounded-[32px] px-6 pt-8 pb-10"
+          : "w-[292px] min-w-[292px] gap-7.5 rounded-3xl px-4 py-6"
+      )}
+    >
+      <ModalHeader id={titleId} title={title} size={size} onClose={onClose} />
+
+      <div className="flex min-h-0 w-full flex-1 flex-col items-start gap-6 overflow-y-auto">
+        <InputSearchbar
+          size={isMd ? "md" : "sm"}
+          value={searchValue}
+          onChange={onSearchChange}
+          onSearch={onSearch}
+        />
+
+        {results.length > 0 && (
+          <div className="flex w-full flex-col gap-4">
+            {results.map((result) => (
+              <AddressCard
+                key={result.zipCode}
+                size={size}
+                zipCode={result.zipCode}
+                roadAddress={result.roadAddress}
+                lotAddress={result.lotAddress}
+                selected={result.zipCode === selectedZipCode}
+                onClick={() => onSelect(result)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Button
+        variant="solid"
+        size={isMd ? "md" : "sm"}
+        className="shrink-0"
+        disabled={!canConfirm}
+        onClick={onConfirm}
+      >
+        선택완료
+      </Button>
+    </Modal>
+  );
+}

--- a/src/component/common/address-select-modal.tsx
+++ b/src/component/common/address-select-modal.tsx
@@ -56,7 +56,7 @@ export default function AddressSelectModal({
       labelledBy={titleId}
       className={clsx(
         isMd
-          ? "w-140 min-w-140 gap-10 rounded-[32px] px-6 pt-8 pb-10"
+          ? "w-152 min-w-152 gap-10 rounded-[32px] px-6 pt-8 pb-10"
           : "w-[292px] min-w-[292px] gap-7.5 rounded-3xl px-4 py-6"
       )}
     >

--- a/src/component/common/filter-modal.tsx
+++ b/src/component/common/filter-modal.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useId } from "react";
+import Button from "@/component/common/button";
+import CheckboxButton from "@/component/common/checkbox-button";
+import Chip, { SERVICES, SERVICE_LABELS, type ServiceCode } from "@/component/common/chip-region";
+import Modal, { ModalHeader } from "@/component/common/modal";
+
+interface FilterModalProps {
+  open: boolean;
+  onClose: () => void;
+  moveType?: ServiceCode;
+  onMoveTypeChange: (value: ServiceCode) => void;
+  isTargetedOnly: boolean;
+  onTargetedOnlyChange: (value: boolean) => void;
+  isServiceAreaOnly: boolean;
+  onServiceAreaOnlyChange: (value: boolean) => void;
+  onApply: () => void;
+}
+
+// 모바일 필터 바텀시트 (이사 유형 / 지역·견적)
+export default function FilterModal({
+  open,
+  onClose,
+  moveType,
+  onMoveTypeChange,
+  isTargetedOnly,
+  onTargetedOnlyChange,
+  isServiceAreaOnly,
+  onServiceAreaOnlyChange,
+  onApply,
+}: FilterModalProps) {
+  const titleId = useId();
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      position="bottom"
+      labelledBy={titleId}
+      className="w-93.75 min-w-93.75 gap-8 rounded-t-[32px] px-6 pt-6 pb-8"
+    >
+      <ModalHeader id={titleId} title="필터" size="sm" onClose={onClose} />
+
+      <div className="flex min-h-0 w-full flex-1 flex-col items-start gap-7 overflow-y-auto">
+        <div className="flex w-full flex-col items-start gap-2">
+          <p className="text-16 text-black-black-400 font-semibold">이사 유형</p>
+          <div
+            className="flex flex-wrap items-center gap-3"
+            role="group"
+            aria-label="이사 유형 선택"
+          >
+            {SERVICES.map((service) => (
+              <Chip
+                key={service}
+                size="sm"
+                selected={moveType === service}
+                onClick={() => onMoveTypeChange(service)}
+              >
+                {SERVICE_LABELS[service]}
+              </Chip>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex w-full flex-col items-start gap-2">
+          <p className="text-16 text-black-black-400 font-semibold">지역 및 견적</p>
+          <div className="flex flex-col gap-3">
+            <label className="flex items-center">
+              <CheckboxButton
+                shape="square"
+                checked={isTargetedOnly}
+                onChange={(event) => onTargetedOnlyChange(event.target.checked)}
+              />
+              <span className="text-16 text-black-500 font-normal">지정 견적 요청</span>
+            </label>
+            <label className="flex items-center">
+              <CheckboxButton
+                shape="square"
+                checked={isServiceAreaOnly}
+                onChange={(event) => onServiceAreaOnlyChange(event.target.checked)}
+              />
+              <span className="text-16 text-black-500 font-normal">서비스 가능 지역</span>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <Button variant="solid" size="sm" className="shrink-0" onClick={onApply}>
+        조회하기
+      </Button>
+    </Modal>
+  );
+}

--- a/src/component/common/info-required-modal.tsx
+++ b/src/component/common/info-required-modal.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import clsx from "clsx";
+import { useId } from "react";
+import Button from "@/component/common/button";
+import Modal, { ModalHeader } from "@/component/common/modal";
+
+type InfoRequiredModalSize = "sm" | "md";
+
+interface InfoRequiredModalProps {
+  open: boolean;
+  onClose: () => void;
+  size?: InfoRequiredModalSize;
+  title?: string;
+  message?: string;
+  actionLabel?: string;
+  onAction: () => void;
+}
+
+export default function InfoRequiredModal({
+  open,
+  onClose,
+  size = "md",
+  title = "지정 견적 요청하기",
+  message = "일반 견적 요청을 먼저 진행해 주세요.",
+  actionLabel = "일반 견적 요청 하기",
+  onAction,
+}: InfoRequiredModalProps) {
+  const titleId = useId();
+  const isMd = size === "md";
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      position="center"
+      labelledBy={titleId}
+      className={clsx(
+        isMd
+          ? "w-140 min-w-140 gap-10 rounded-[32px] px-6 pt-8 pb-10"
+          : "w-[292px] min-w-[292px] gap-7.5 rounded-3xl px-4 py-6"
+      )}
+    >
+      <ModalHeader id={titleId} title={title} size={size} onClose={onClose} />
+      <p className="text-18 text-black-300 min-h-0 w-full flex-1 overflow-y-auto font-medium">
+        {message}
+      </p>
+      <Button variant="solid" size={isMd ? "md" : "sm"} className="shrink-0" onClick={onAction}>
+        {actionLabel}
+      </Button>
+    </Modal>
+  );
+}

--- a/src/component/common/info-required-modal.tsx
+++ b/src/component/common/info-required-modal.tsx
@@ -37,7 +37,7 @@ export default function InfoRequiredModal({
       labelledBy={titleId}
       className={clsx(
         isMd
-          ? "w-140 min-w-140 gap-10 rounded-[32px] px-6 pt-8 pb-10"
+          ? "w-152 min-w-152 gap-10 rounded-[32px] px-6 pt-8 pb-10"
           : "w-[292px] min-w-[292px] gap-7.5 rounded-3xl px-4 py-6"
       )}
     >

--- a/src/component/common/modal.tsx
+++ b/src/component/common/modal.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import clsx from "clsx";
+import Image from "next/image";
+import type { ReactNode } from "react";
+import xMd from "@/assets/icons/x-md.svg";
+import xSm from "@/assets/icons/x-sm.svg";
+import { useDialog } from "@/hooks/use-dialog";
+
+type ModalPosition = "center" | "bottom";
+type ModalHeaderSize = "sm" | "md";
+
+export interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  position?: ModalPosition;
+  labelledBy?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export default function Modal({
+  open,
+  onClose,
+  position = "center",
+  labelledBy,
+  children,
+  className,
+}: ModalProps) {
+  const { panelRef } = useDialog({ open, onClose });
+
+  if (!open) return null;
+
+  return (
+    <div className="z-modal bg-overlay-dim fixed inset-0 overflow-auto">
+      <div
+        className={clsx(
+          "flex min-h-full",
+          position === "bottom" ? "items-end justify-center" : "items-center justify-center p-4"
+        )}
+        onClick={(event) => {
+          if (event.target === event.currentTarget) onClose();
+        }}
+      >
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={labelledBy}
+          tabIndex={-1}
+          className={clsx(
+            "shadow-modal relative flex min-h-0 flex-none flex-col items-stretch overflow-hidden bg-gray-50 outline-none",
+            position === "bottom" ? "max-h-dvh" : "max-h-[calc(100dvh-2rem)]",
+            className
+          )}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export interface ModalHeaderProps {
+  id?: string;
+  title: string;
+  size?: ModalHeaderSize;
+  onClose: () => void;
+}
+
+export function ModalHeader({ id, title, size = "sm", onClose }: ModalHeaderProps) {
+  const isMd = size === "md";
+
+  return (
+    <div className="flex w-full shrink-0 items-center justify-between bg-gray-50">
+      <p
+        id={id}
+        className={clsx(
+          "text-black-black-400 shrink-0 whitespace-nowrap",
+          isMd ? "text-24 font-semibold" : "text-18 font-bold"
+        )}
+      >
+        {title}
+      </p>
+      <button type="button" onClick={onClose} aria-label="닫기" className="shrink-0">
+        <Image src={isMd ? xMd : xSm} alt="" className={isMd ? "size-9" : "size-6"} />
+      </button>
+    </div>
+  );
+}

--- a/src/component/common/quote-action-modal.tsx
+++ b/src/component/common/quote-action-modal.tsx
@@ -76,7 +76,7 @@ export default function QuoteActionModal({
       className={clsx(
         "px-6 pt-8 pb-10",
         isMd
-          ? "w-140 min-w-140 gap-10 rounded-[32px]"
+          ? "w-152 min-w-152 gap-10 rounded-[32px]"
           : "w-93.75 min-w-93.75 gap-6.5 rounded-t-[32px]"
       )}
     >
@@ -116,7 +116,7 @@ export default function QuoteActionModal({
                 size={isMd ? "md" : "sm"}
                 placeholder="견적가 입력"
                 value={price}
-                onChange={(event) => onPriceChange?.(event.target.value)}
+                onChange={(event) => onPriceChange?.(event.target.value.replace(/\D/g, ""))}
               />
               <p className={clsx("text-black-300 font-semibold", isMd ? "text-18" : "text-16")}>
                 코멘트를 입력해 주세요

--- a/src/component/common/quote-action-modal.tsx
+++ b/src/component/common/quote-action-modal.tsx
@@ -111,7 +111,7 @@ export default function QuoteActionModal({
                 견적가를 입력해 주세요
               </p>
               <InputTextField
-                type="password"
+                type="text"
                 inputMode="numeric"
                 size={isMd ? "md" : "sm"}
                 placeholder="견적가 입력"

--- a/src/component/common/quote-action-modal.tsx
+++ b/src/component/common/quote-action-modal.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import clsx from "clsx";
+import { useId } from "react";
+import Button from "@/component/common/button";
+import type { ServiceCode } from "@/component/common/chip-region";
+import MoveTypeChip from "@/component/common/chip-move-type";
+import InputTextArea from "@/component/common/input-textarea";
+import InputTextField from "@/component/common/input-textfield";
+import Modal, { ModalHeader } from "@/component/common/modal";
+import MovingInfo from "@/component/common/moving-info";
+
+type QuoteActionVariant = "send" | "reject";
+type QuoteActionSize = "sm" | "md";
+
+interface QuoteActionModalProps {
+  open: boolean;
+  onClose: () => void;
+  // send: 견적 보내기 / reject: 반려요청
+  variant: QuoteActionVariant;
+  size?: QuoteActionSize;
+  category: ServiceCode;
+  // 지정 견적 여부. 이 모달은 지정 견적 전용이라 기본값 true
+  isTargeted?: boolean;
+  customerName: string;
+  fromAddress: string;
+  toAddress: string;
+  movingDate: string;
+  price?: string;
+  onPriceChange?: (value: string) => void;
+  comment?: string;
+  onCommentChange?: (value: string) => void;
+  reason?: string;
+  onReasonChange?: (value: string) => void;
+  onSubmit: () => void;
+}
+
+const TITLE: Record<QuoteActionVariant, string> = {
+  send: "견적 보내기",
+  reject: "반려요청",
+};
+
+// 견적 보내기 / 반려요청 모달
+export default function QuoteActionModal({
+  open,
+  onClose,
+  variant,
+  size = "md",
+  category,
+  isTargeted = true,
+  customerName,
+  fromAddress,
+  toAddress,
+  movingDate,
+  price = "",
+  onPriceChange,
+  comment = "",
+  onCommentChange,
+  reason = "",
+  onReasonChange,
+  onSubmit,
+}: QuoteActionModalProps) {
+  const titleId = useId();
+  const isMd = size === "md";
+  const isSend = variant === "send";
+  const isValid = isSend
+    ? price.trim().length > 0 && comment.trim().length >= 10
+    : reason.trim().length >= 10;
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      position={isMd ? "center" : "bottom"}
+      labelledBy={titleId}
+      className={clsx(
+        "px-6 pt-8 pb-10",
+        isMd
+          ? "w-140 min-w-140 gap-10 rounded-[32px]"
+          : "w-93.75 min-w-93.75 gap-6.5 rounded-t-[32px]"
+      )}
+    >
+      <ModalHeader id={titleId} title={TITLE[variant]} size={size} onClose={onClose} />
+
+      <div className="flex min-h-0 w-full flex-1 flex-col gap-6.5 overflow-y-auto">
+        <div className="flex w-full flex-col items-start gap-5">
+          <div className="flex items-center gap-2">
+            <MoveTypeChip variant={category} size={isMd ? "md" : "sm"} />
+            {isTargeted && <MoveTypeChip variant="TARGETED" size={isMd ? "md" : "sm"} />}
+          </div>
+
+          <p className="text-20 text-black-300 flex w-full min-w-0 items-center gap-1 font-semibold">
+            <span className="min-w-0 truncate">{customerName}</span>
+            <span className="shrink-0">고객님</span>
+          </p>
+
+          <MovingInfo
+            from={fromAddress}
+            to={toAddress}
+            movingDate={movingDate}
+            size={isMd ? "lg" : "sm"}
+          />
+
+          {isMd && <hr className="border-line-100 w-full border-t" />}
+        </div>
+
+        <div className="flex w-full flex-col items-start gap-4">
+          {isSend ? (
+            <>
+              <p className={clsx("text-black-300 font-semibold", isMd ? "text-18" : "text-16")}>
+                견적가를 입력해 주세요
+              </p>
+              <InputTextField
+                type="password"
+                inputMode="numeric"
+                size={isMd ? "md" : "sm"}
+                placeholder="견적가 입력"
+                value={price}
+                onChange={(event) => onPriceChange?.(event.target.value)}
+              />
+              <p className={clsx("text-black-300 font-semibold", isMd ? "text-18" : "text-16")}>
+                코멘트를 입력해 주세요
+              </p>
+              <InputTextArea
+                size={isMd ? "md" : "sm"}
+                placeholder="최소 10자 이상 입력해주세요"
+                value={comment}
+                onChange={(event) => onCommentChange?.(event.target.value)}
+              />
+            </>
+          ) : (
+            <>
+              <p className={clsx("text-black-300 font-semibold", isMd ? "text-20" : "text-16")}>
+                반려 사유를 입력해 주세요
+              </p>
+              <InputTextArea
+                size={isMd ? "md" : "sm"}
+                placeholder="최소 10자 이상 입력해주세요"
+                value={reason}
+                onChange={(event) => onReasonChange?.(event.target.value)}
+              />
+            </>
+          )}
+        </div>
+      </div>
+
+      <Button
+        variant="solid"
+        size={isMd ? "md" : "sm"}
+        className="shrink-0"
+        disabled={!isValid}
+        onClick={onSubmit}
+      >
+        {isSend ? "견적 보내기" : "반려하기"}
+      </Button>
+    </Modal>
+  );
+}

--- a/src/component/common/review-write-modal.tsx
+++ b/src/component/common/review-write-modal.tsx
@@ -66,12 +66,11 @@ export default function ReviewWriteModal({
       onClose={onClose}
       position={isMd ? "center" : "bottom"}
       labelledBy={titleId}
-      className={clsx(
-        "gap-8 p-8",
+      className={
         isMd
-          ? "w-150 min-w-150 rounded-[32px]"
+          ? "w-150 min-w-150 gap-8 rounded-[32px] p-8"
           : "w-93.75 min-w-93.75 gap-6.5 rounded-t-[32px] px-6 py-8"
-      )}
+      }
     >
       <ModalHeader id={titleId} title="리뷰 쓰기" size={size} onClose={onClose} />
 

--- a/src/component/common/review-write-modal.tsx
+++ b/src/component/common/review-write-modal.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import clsx from "clsx";
+import Image from "next/image";
+import { useId } from "react";
+import starLgActive from "@/assets/icons/star-lg-active.svg";
+import starLgDefault from "@/assets/icons/star-lg-default.svg";
+import starMdActive from "@/assets/icons/star-md-active.svg";
+import starMdDefault from "@/assets/icons/star-md-default.svg";
+import Button from "@/component/common/button";
+import type { ServiceCode } from "@/component/common/chip-region";
+import MoveTypeChip from "@/component/common/chip-move-type";
+import InputTextArea from "@/component/common/input-textarea";
+import Modal, { ModalHeader } from "@/component/common/modal";
+import MoverName from "@/component/common/mover-name";
+import MovingInfo from "@/component/common/moving-info";
+import ProfileAvatar from "@/component/common/profile-avatar";
+
+type ReviewWriteModalSize = "sm" | "md";
+
+const MIN_REVIEW_LENGTH = 10;
+
+interface ReviewWriteModalProps {
+  open: boolean;
+  onClose: () => void;
+  size?: ReviewWriteModalSize;
+  category: ServiceCode;
+  isTargeted?: boolean;
+  moverNickName: string;
+  moverProfileImage?: string | null;
+  fromAddress: string;
+  toAddress: string;
+  movingDate: string;
+  rating: number;
+  onRatingChange: (rating: number) => void;
+  review: string;
+  onReviewChange: (review: string) => void;
+  onSubmit: () => void;
+}
+
+// 리뷰 작성 모달
+export default function ReviewWriteModal({
+  open,
+  onClose,
+  size = "md",
+  category,
+  isTargeted = true,
+  moverNickName,
+  moverProfileImage,
+  fromAddress,
+  toAddress,
+  movingDate,
+  rating,
+  onRatingChange,
+  review,
+  onReviewChange,
+  onSubmit,
+}: ReviewWriteModalProps) {
+  const titleId = useId();
+  const isMd = size === "md";
+  const isValid = rating > 0 && review.trim().length >= MIN_REVIEW_LENGTH;
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      position={isMd ? "center" : "bottom"}
+      labelledBy={titleId}
+      className={clsx(
+        "gap-8 p-8",
+        isMd
+          ? "w-150 min-w-150 rounded-[32px]"
+          : "w-93.75 min-w-93.75 gap-6.5 rounded-t-[32px] px-6 py-8"
+      )}
+    >
+      <ModalHeader id={titleId} title="리뷰 쓰기" size={size} onClose={onClose} />
+
+      <div className="flex min-h-0 w-full flex-1 flex-col items-start gap-8 overflow-y-auto">
+        <div className="flex w-full flex-col items-start gap-4">
+          <div className="flex items-center gap-2">
+            <MoveTypeChip variant={category} size={isMd ? "md" : "sm"} />
+            {isTargeted && <MoveTypeChip variant="TARGETED" size={isMd ? "md" : "sm"} />}
+          </div>
+
+          <div className="flex w-full items-center justify-between">
+            <MoverName nickName={moverNickName} size={isMd ? "md" : "sm"} />
+            <ProfileAvatar src={moverProfileImage} alt={moverNickName} size="sm" />
+          </div>
+
+          <hr className="border-line-100 w-full border-t" />
+
+          <MovingInfo
+            from={fromAddress}
+            to={toAddress}
+            movingDate={movingDate}
+            size={isMd ? "lg" : "sm"}
+          />
+
+          <hr className="border-line-100 w-full border-t" />
+        </div>
+
+        <div className="flex w-full flex-col items-start gap-3">
+          <p className={clsx("text-black-300 font-semibold", isMd ? "text-18" : "text-16")}>
+            평점을 선택해 주세요
+          </p>
+          <StarRatingInput size={size} value={rating} onChange={onRatingChange} />
+        </div>
+
+        <div className="flex w-full flex-col items-start gap-3">
+          <p className={clsx("text-black-300 font-semibold", isMd ? "text-18" : "text-16")}>
+            상세 후기를 작성해 주세요
+          </p>
+          <InputTextArea
+            size={isMd ? "md" : "sm"}
+            placeholder="최소 10자 이상 입력해주세요"
+            value={review}
+            onChange={(event) => onReviewChange(event.target.value)}
+          />
+        </div>
+      </div>
+
+      <Button
+        variant="solid"
+        size={isMd ? "md" : "sm"}
+        className="shrink-0"
+        disabled={!isValid}
+        onClick={onSubmit}
+      >
+        리뷰 등록
+      </Button>
+    </Modal>
+  );
+}
+
+function StarRatingInput({
+  size,
+  value,
+  onChange,
+}: {
+  size: ReviewWriteModalSize;
+  value: number;
+  onChange: (rating: number) => void;
+}) {
+  const isMd = size === "md";
+  const activeIcon = isMd ? starLgActive : starMdActive;
+  const defaultIcon = isMd ? starLgDefault : starMdDefault;
+
+  return (
+    <div role="radiogroup" aria-label="평점" className="flex items-start">
+      {[1, 2, 3, 4, 5].map((star) => (
+        <button
+          key={star}
+          type="button"
+          role="radio"
+          aria-checked={value === star}
+          aria-label={`${star}점`}
+          onClick={() => onChange(star)}
+        >
+          <Image
+            src={star <= value ? activeIcon : defaultIcon}
+            alt=""
+            className={isMd ? "size-9" : "size-6"}
+          />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/component/common/review-write-modal.tsx
+++ b/src/component/common/review-write-modal.tsx
@@ -111,6 +111,7 @@ export default function ReviewWriteModal({
           </p>
           <InputTextArea
             size={isMd ? "md" : "sm"}
+            label="상세 후기"
             placeholder="최소 10자 이상 입력해주세요"
             value={review}
             onChange={(event) => onReviewChange(event.target.value)}

--- a/src/component/common/toast.tsx
+++ b/src/component/common/toast.tsx
@@ -17,8 +17,8 @@ export default function Toast({ message, size = "sm", className, ...props }: Toa
       role="status"
       aria-live="polite"
       className={clsx(
-        "z-toast shadow-modal fixed bottom-10 left-1/2 -translate-x-1/2 rounded-2xl bg-orange-200 font-semibold text-orange-400",
-        isMd ? "text-16 px-6 py-4" : "text-14 px-4 py-3",
+        "z-toast shadow-modal fixed bottom-10 left-1/2 -translate-x-1/2 bg-orange-200 font-semibold text-orange-400",
+        isMd ? "text-18 rounded-2xl px-8 py-5" : "text-16 rounded-xl px-6 py-3.5",
         className
       )}
       {...props}

--- a/src/component/common/toast.tsx
+++ b/src/component/common/toast.tsx
@@ -1,0 +1,29 @@
+import clsx from "clsx";
+import type { HTMLAttributes } from "react";
+
+type ToastSize = "sm" | "md";
+
+interface ToastProps extends HTMLAttributes<HTMLDivElement> {
+  message: string;
+  size?: ToastSize;
+}
+
+// 안내 토스트. 닫기는 호출부에서 setTimeout으로 처리.
+export default function Toast({ message, size = "sm", className, ...props }: ToastProps) {
+  const isMd = size === "md";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={clsx(
+        "z-toast shadow-modal fixed bottom-10 left-1/2 -translate-x-1/2 rounded-2xl bg-orange-200 font-semibold text-orange-400",
+        isMd ? "text-16 px-6 py-4" : "text-14 px-4 py-3",
+        className
+      )}
+      {...props}
+    >
+      {message}
+    </div>
+  );
+}

--- a/src/hooks/use-dialog.ts
+++ b/src/hooks/use-dialog.ts
@@ -10,6 +10,11 @@ interface UseDialogOptions {
 // Escape 닫기, 배경 스크롤 락, 포커스 트랩. 바깥 클릭 닫기는 Modal에서 처리.
 export function useDialog({ open, onClose }: UseDialogOptions) {
   const panelRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
 
   useEffect(() => {
     if (!open) return;
@@ -22,7 +27,7 @@ export function useDialog({ open, onClose }: UseDialogOptions) {
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        onClose();
+        onCloseRef.current();
         return;
       }
       if (event.key !== "Tab") return;
@@ -51,7 +56,7 @@ export function useDialog({ open, onClose }: UseDialogOptions) {
       document.body.style.overflow = previousOverflow;
       previouslyFocused?.focus();
     };
-  }, [open, onClose]);
+  }, [open]);
 
   return { panelRef };
 }

--- a/src/hooks/use-dialog.ts
+++ b/src/hooks/use-dialog.ts
@@ -41,7 +41,10 @@ export function useDialog({ open, onClose }: UseDialogOptions) {
       const first = focusable[0];
       const last = focusable[focusable.length - 1];
 
-      if (event.shiftKey && document.activeElement === first) {
+      if (
+        event.shiftKey &&
+        (document.activeElement === panelRef.current || document.activeElement === first)
+      ) {
         event.preventDefault();
         last.focus();
       } else if (!event.shiftKey && document.activeElement === last) {

--- a/src/hooks/use-dialog.ts
+++ b/src/hooks/use-dialog.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface UseDialogOptions {
+  open: boolean;
+  onClose: () => void;
+}
+
+// Escape 닫기, 배경 스크롤 락, 포커스 트랩. 바깥 클릭 닫기는 Modal에서 처리.
+export function useDialog({ open, onClose }: UseDialogOptions) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    // 닫힌 뒤 원래 포커스로 되돌리기 위해 열어 두기 전 엘리먼트를 기억
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    panelRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      // Tab이 모달 밖으로 나가지 않게 처음/끝에서 순환
+      const focusable = panelRef.current?.querySelectorAll<HTMLElement>(
+        'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+      );
+      if (!focusable || focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+      previouslyFocused?.focus();
+    };
+  }, [open, onClose]);
+
+  return { panelRef };
+}


### PR DESCRIPTION
## 📌 개요
- 피그마 Modal / Pop-up 공통 컴포넌트 구현
- 공용 `Modal` 셸 + `useDialog`(Escape, 스크롤 락, 포커스 트랩) 위에 주소 선택 / 견적보내기·반려 / 일반요청 / 필터 / 리뷰쓰기 / 토스트를 구성했습니다
- 기존 `Button`, `MovingInfo`, Input, Chip 등을 재사용했고, 공통 `Button` 스펙은 변경하지 않았습니다

## 🔢 Linked Issue
- close #36 

## 🛠️ 주요 변경 사항
- [x] 공용 `Modal` / `ModalHeader`와 `useDialog` 훅 추가
- [x] 주소 선택, 견적보내기·반려, 일반 요청 필요, 필터 바텀시트, 리뷰 쓰기 모달 및 토스트 구현
- [x] `globals.css`에 모달 그림자·주소 카드 그림자, `--z-modal`(1100) / `--z-toast`(1200) 토큰 추가
- [x] 퍼블리싱 확인용 테스트 페이지 `/component-modal-popup` 추가

## 📸 스크린샷 (선택)
- `/component-modal-popup`에서 sm / md 확인 부탁드립니다

## 🧪 테스트 결과 & 리뷰 요청 사항
- `/component-modal-popup`에서 각 모달 sm/md, 필터 바텀시트, 토스트(2초) 동작 확인
- 창을 줄여도 패널·헤더·CTA 폭/높이가 안 줄어들고, 본문만 스크롤되는지 봐주세요
- 공통 `Button` md 높이는 60px 유지입니다 (피그마 CTA 64px와 다를 수 있음)
- 견적/리뷰 sm 출발지 줄은 `MovingInfo` 재사용이라 카드와 같은 라벨 위 / 값 아래 레이아웃입니다

## 📋 완료 체크리스트
- [x] 브랜치 방향(To dev)을 올바르게 설정했나요?
- [x] 무관한 파일이나 테스트용 코드가 커밋에 포함되지 않았나요?
- [x] (`npm run dev`) 시 에러가 발생하지 않나요?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 주소 검색·선택, 필터 설정, 견적 제출·반려, 정보 요청, 후기 작성 모달을 추가했습니다.
  - 중앙 모달과 모바일 하단 시트 형태를 지원합니다.
  - 입력값 검증과 선택 상태를 제공하며, 필수 조건 충족 시에만 제출할 수 있습니다.
  - 안내 토스트와 주소 결과 카드 UI를 추가했습니다.
  - 모달 데모 페이지에서 다양한 상태와 동작을 확인할 수 있습니다.
  - 키보드 포커스 관리, ESC 닫기, 배경 스크롤 제어를 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->