### PR TITLE
refactor: Filter·Sort z-index 토큰 적용

### DIFF
--- a/src/component/common/dropdown-notification.tsx
+++ b/src/component/common/dropdown-notification.tsx
@@ -40,7 +40,7 @@ export interface DropdownNotificationProps {
  *   </button>
  *   {open ? (
  *     <DropdownNotification
- *       className="absolute z-1010 ..."
+ *       className="absolute z-[var(--z-gnb-dropdown)] ..."
  *       containerRef={wrapRef}
  *       onClose={() => setOpen(false)}
  *     >

--- a/src/component/common/filter.tsx
+++ b/src/component/common/filter.tsx
@@ -206,9 +206,8 @@ function SingleList({ id, size, options, value, onSelect }: SingleListProps) {
     <ul
       id={id}
       aria-label="필터 옵션"
-      // TODO: z-index 토큰(--z-filter-dropdown) PR 머지 후 z-filter-dropdown으로 교체
       className={clsx(
-        "absolute z-100 flex flex-col overflow-hidden bg-gray-50",
+        "absolute z-[var(--z-filter-dropdown)] flex flex-col overflow-hidden bg-gray-50",
         isSm
           ? "border-line-200 top-[47px] -left-px w-[106px] rounded-lg border shadow-[4px_4px_10px_rgba(191,191,191,0.2)]"
           : "border-line-200 top-[61px] left-0 w-40 rounded-xl border shadow-[4px_4px_5px_rgba(224,224,224,0.25)]"
@@ -301,9 +300,8 @@ function DoubleList({ id, size, columns, value, onSelect }: DoubleListProps) {
       id={id}
       role="group"
       aria-label="지역 필터 옵션"
-      // TODO: z-index 토큰(--z-filter-dropdown) PR 머지 후 z-filter-dropdown으로 교체
       className={clsx(
-        "absolute -left-px z-100 overflow-hidden bg-gray-50",
+        "absolute -left-px z-[var(--z-filter-dropdown)] overflow-hidden bg-gray-50",
         isSm
           ? "border-line-200 top-[47px] max-h-45 rounded-lg border shadow-[4px_4px_10px_rgba(191,191,191,0.2)]"
           : "top-[61px] max-h-80 rounded-2xl shadow-[4px_4px_5px_rgba(224,224,224,0.25)]"

--- a/src/component/common/sort.tsx
+++ b/src/component/common/sort.tsx
@@ -126,9 +126,8 @@ export default function Sort({
         <ul
           id={listId}
           aria-label="정렬 옵션"
-          // TODO: z-index 토큰(--z-filter-dropdown) PR 머지 후 z-filter-dropdown으로 교체
           className={clsx(
-            "border-line-100 absolute top-full left-0 z-100 flex flex-col overflow-hidden rounded-lg border bg-gray-50",
+            "border-line-100 absolute top-full left-0 z-[var(--z-filter-dropdown)] flex flex-col overflow-hidden rounded-lg border bg-gray-50",
             isSm ? "mt-1.5 w-[91px]" : "mt-2 w-[114px]"
           )}
         >


### PR DESCRIPTION
## 📌 개요

Filter·Sort 드롭다운의 하드코딩 `z-100`과 TODO를 `--z-filter-dropdown` 토큰으로 교체합니다.
동작(값 100)은 동일하고, 알림 드롭다운 JSDoc 예시도 토큰에 맞춥니다.

## 🔢 Linked Issue

- close #59

## 🛠️ 주요 변경 사항

- [x] `sort.tsx` / `filter.tsx` — `z-100` → `z-[var(--z-filter-dropdown)]`, TODO 제거
- [x] `dropdown-notification.tsx` — JSDoc 예시 `z-1010` → `--z-gnb-dropdown`

## 📸 스크린샷 (선택)


## 🧪 테스트 결과 & 리뷰 요청 사항

- z-index 값은 기존과 동일(`100`)이라 시각 변화 없음

## 📋 완료 체크리스트

- [x] 브랜치 방향(To dev)을 올바르게 설정했나요?
- [x] 무관한 파일이나 테스트용 코드가 커밋에 포함되지 않았나요?
- [x] (`npm run dev`) 시 에러가 발생하지 않나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 필터 및 정렬 드롭다운의 표시 우선순위를 고정값 대신 CSS 변수로 관리하도록 변경했습니다.
  * 알림 드롭다운 예시의 레이어 우선순위도 CSS 변수 기반으로 정리했습니다.
  * 관련 안내 주석을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->