### PR TITLE
feat: 공통 컴포넌트 Card-list 작업 (리뷰 계열)

### DIFF
--- a/src/app/(main)/component-card-list/page.tsx
+++ b/src/app/(main)/component-card-list/page.tsx
@@ -225,14 +225,21 @@ export default function CardListPage() {
         </W>
       </Section>
 
-      <Section title="Card-list-review / lg 955 ・ sm 600 (테두리 없음 - 목록 행)">
+      {/* 실제 사용 폭: lg 600·766·821·955 / sm 335 (UI Design 집계) */}
+      <Section title="Card-list-review / lg 955・821・766・600 ・ sm 335 (테두리 없음 - 목록 행)">
         <W px={955}>
           <CardReview size="lg" {...REVIEW} />
         </W>
-        <W px={600}>
-          <CardReview {...REVIEW} />
+        <W px={821}>
+          <CardReview size="lg" {...REVIEW} />
+        </W>
+        <W px={766}>
+          <CardReview size="lg" {...REVIEW} />
         </W>
         <W px={600}>
+          <CardReview size="lg" {...REVIEW} />
+        </W>
+        <W px={335}>
           <CardReview {...REVIEW} rating={3} />
         </W>
       </Section>

--- a/src/app/(main)/component-card-list/page.tsx
+++ b/src/app/(main)/component-card-list/page.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import { CardEstimateHistory, CardPendingHistory } from "@/component/common/card-estimate";
 import CardMover from "@/component/common/card-mover";
+import CardMyReview from "@/component/common/card-my-review";
+import CardReview from "@/component/common/card-review";
 import {
   CardCompleted,
   CardCustomerQuotation,
@@ -41,6 +43,29 @@ const MOVER = {
   career: 7,
   confirmedCount: 334,
   favoriteCount: 136,
+} as const;
+
+/** 리뷰 카드용 목업 */
+const REVIEW = {
+  writer: "kim****",
+  createdAt: "2024-07-01",
+  rating: 5,
+  content:
+    "듣던대로 정말 친절하시고 물건도 잘 옮겨주셨어요~~ 나중에 또 짐 옮길 일 있으면 김코드 기사님께 부탁드릴 예정입니다!! 비 오는데 꼼꼼히 잘 해주셔서 감사드립니다 :)",
+} as const;
+
+/** 내가 작성한 리뷰 카드용 목업 */
+const MY_REVIEW = {
+  category: "SMALL",
+  nickName: "김코드",
+  description: "이사업계 경력 7년으로 안전한 이사를 도와드리는 김코드입니다.",
+  from: "서울시 중구",
+  to: "경기도 수원시",
+  movingDate: "2024년 07월 01일",
+  rating: 5,
+  content:
+    "처음 견적 받아봤는데, 엄청 친절하시고 꼼꼼하세요! 귀찮게 이것저것 물어봤는데 잘 알려주셨습니다. 원룸 이사는 믿고 맡기세요! :) 곧 이사 앞두고 있는 지인분께 추천드릴 예정입니다!",
+  createdAt: "2024.07.02",
 } as const;
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
@@ -185,6 +210,30 @@ export default function CardListPage() {
         </W>
         <W px={327}>
           <CardEstimateHistory category="OFFICE" isTargeted {...MOVER} price={180000} isConfirmed />
+        </W>
+      </Section>
+
+      <Section title="Card-list-review / lg 955 ・ sm 600 (테두리 없음 - 목록 행)">
+        <W px={955}>
+          <CardReview size="lg" {...REVIEW} />
+        </W>
+        <W px={600}>
+          <CardReview {...REVIEW} />
+        </W>
+        <W px={600}>
+          <CardReview {...REVIEW} rating={3} />
+        </W>
+      </Section>
+
+      <Section title="내가 작성한 리뷰 / lg 588 · 1120 · sm 327">
+        <W px={588}>
+          <CardMyReview size="lg" {...MY_REVIEW} />
+        </W>
+        <W px={1120}>
+          <CardMyReview size="lg" {...MY_REVIEW} />
+        </W>
+        <W px={327}>
+          <CardMyReview {...MY_REVIEW} isTargeted />
         </W>
       </Section>
 

--- a/src/app/(main)/component-card-list/page.tsx
+++ b/src/app/(main)/component-card-list/page.tsx
@@ -5,6 +5,7 @@ import { CardEstimateHistory, CardPendingHistory } from "@/component/common/card
 import CardMover from "@/component/common/card-mover";
 import CardMyReview from "@/component/common/card-my-review";
 import CardReview from "@/component/common/card-review";
+import CardWritableReview from "@/component/common/card-writable-review";
 import {
   CardCompleted,
   CardCustomerQuotation,
@@ -66,6 +67,17 @@ const MY_REVIEW = {
   content:
     "처음 견적 받아봤는데, 엄청 친절하시고 꼼꼼하세요! 귀찮게 이것저것 물어봤는데 잘 알려주셨습니다. 원룸 이사는 믿고 맡기세요! :) 곧 이사 앞두고 있는 지인분께 추천드릴 예정입니다!",
   createdAt: "2024.07.02",
+} as const;
+
+/** 작성 가능한 리뷰 카드용 목업 */
+const WRITABLE = {
+  category: "SMALL",
+  nickName: "김코드",
+  description: "이사업계 경력 7년으로 안전한 이사를 도와드리는 김코드입니다.",
+  from: "서울시 중구",
+  to: "경기도 수원시",
+  movingDate: "2024년 07월 01일 (월)",
+  price: 180000,
 } as const;
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
@@ -234,6 +246,27 @@ export default function CardListPage() {
         </W>
         <W px={327}>
           <CardMyReview {...MY_REVIEW} isTargeted />
+        </W>
+      </Section>
+
+      <Section title="작성 가능한 리뷰 / lg 1120 · md 600 · sm 327 (default · disabled)">
+        <W px={1120}>
+          <CardWritableReview size="lg" {...WRITABLE} />
+        </W>
+        <W px={1120}>
+          <CardWritableReview size="lg" {...WRITABLE} disabled />
+        </W>
+        <W px={600}>
+          <CardWritableReview size="md" {...WRITABLE} />
+        </W>
+        <W px={600}>
+          <CardWritableReview size="md" {...WRITABLE} disabled />
+        </W>
+        <W px={327}>
+          <CardWritableReview {...WRITABLE} isTargeted />
+        </W>
+        <W px={327}>
+          <CardWritableReview {...WRITABLE} isTargeted disabled />
         </W>
       </Section>
 

--- a/src/component/common/card-estimate.tsx
+++ b/src/component/common/card-estimate.tsx
@@ -229,8 +229,8 @@ export function CardPendingHistory({
   return (
     <article
       className={clsx(
-        "border-line-100 flex flex-col items-start border-[0.5px] bg-white",
-        "shadow-[-2px_-2px_10px_0_rgba(220,220,220,0.2),2px_2px_10px_0_rgba(220,220,220,0.2)]",
+        "flex flex-col items-start bg-white",
+        "shadow-[inset_0_0_0_0.5px_var(--color-line-100),-2px_-2px_10px_0_rgba(220,220,220,0.2),2px_2px_10px_0_rgba(220,220,220,0.2)]",
         "w-full",
         isLg ? "gap-10 rounded-[20px] px-10 py-8" : "gap-7 rounded-[20px] px-5 py-6",
         className

--- a/src/component/common/card-estimate.tsx
+++ b/src/component/common/card-estimate.tsx
@@ -60,7 +60,7 @@ function MoverBox({
         bordered && "rounded-xl border border-gray-300 py-3 pr-5 pl-3"
       )}
     >
-      <ProfileAvatar src={profileImage} alt={nickName} size="sm" />
+      <ProfileAvatar src={profileImage} alt={nickName} size="50" />
 
       <div className={clsx("flex min-w-px flex-1 flex-col items-start", isLg ? "gap-2" : "gap-1")}>
         <div className="flex w-full items-center justify-between">

--- a/src/component/common/card-mover.tsx
+++ b/src/component/common/card-mover.tsx
@@ -139,7 +139,7 @@ export default function CardMover({
             )}
           </div>
 
-          <hr className="border-line-100 w-full border-t" />
+          <hr className="h-0 w-full border-0 shadow-[0_0_0_0.5px_var(--color-line-100)]" />
 
           <div className="flex w-full items-center gap-2">
             <ProfileAvatar src={profileImage} alt={nickName} size="50" />

--- a/src/component/common/card-mover.tsx
+++ b/src/component/common/card-mover.tsx
@@ -90,7 +90,7 @@ export default function CardMover({
           </div>
 
           <div className="flex w-full items-start gap-5">
-            <ProfileAvatar src={profileImage} alt={nickName} size="lg" />
+            <ProfileAvatar src={profileImage} alt={nickName} size="134" />
 
             <div className="flex min-w-px flex-1 flex-col gap-5 self-stretch py-1">
               <div className="flex w-full flex-col">
@@ -142,7 +142,7 @@ export default function CardMover({
           <hr className="border-line-100 w-full border-t" />
 
           <div className="flex w-full items-center gap-2">
-            <ProfileAvatar src={profileImage} alt={nickName} size="sm" />
+            <ProfileAvatar src={profileImage} alt={nickName} size="50" />
 
             <div className="flex min-w-0 flex-1 flex-col gap-1">
               <div className="flex w-full items-center justify-between">
@@ -179,7 +179,7 @@ export default function CardMover({
           <p className="text-16 text-black-black-300 w-full font-semibold">{title}</p>
 
           <div className="flex w-full items-center gap-2">
-            <ProfileAvatar src={profileImage} alt={nickName} size="sm" />
+            <ProfileAvatar src={profileImage} alt={nickName} size="50" />
 
             <div className="flex min-w-px flex-1 flex-col gap-1">
               <div className="flex w-full items-center gap-1">

--- a/src/component/common/card-mover.tsx
+++ b/src/component/common/card-mover.tsx
@@ -62,8 +62,8 @@ export default function CardMover({
   const isMd = size === "md";
 
   const cardClass = clsx(
-    "border-line-100 flex flex-col border-[0.5px] bg-white",
-    "shadow-[-2px_-2px_10px_0_rgba(220,220,220,0.2),2px_2px_10px_0_rgba(220,220,220,0.2)]",
+    "flex flex-col bg-white",
+    "shadow-[inset_0_0_0_0.5px_var(--color-line-100),-2px_-2px_10px_0_rgba(220,220,220,0.2),2px_2px_10px_0_rgba(220,220,220,0.2)]",
     "w-full",
     isLg ? "rounded-[20px] px-7 py-6" : "rounded-2xl p-5",
     isMd && "gap-2",
@@ -139,7 +139,7 @@ export default function CardMover({
             )}
           </div>
 
-          <hr className="border-line-100 w-full border-t" />
+          <hr className="w-full border-t" />
 
           <div className="flex w-full items-center gap-2">
             <ProfileAvatar src={profileImage} alt={nickName} size="50" />

--- a/src/component/common/card-mover.tsx
+++ b/src/component/common/card-mover.tsx
@@ -139,7 +139,7 @@ export default function CardMover({
             )}
           </div>
 
-          <hr className="w-full border-t" />
+          <hr className="border-line-100 w-full border-t" />
 
           <div className="flex w-full items-center gap-2">
             <ProfileAvatar src={profileImage} alt={nickName} size="50" />

--- a/src/component/common/card-my-review.tsx
+++ b/src/component/common/card-my-review.tsx
@@ -136,7 +136,7 @@ export default function CardMyReview({
         </div>
       </div>
 
-      <hr className="w-full border-t" />
+      <hr className="border-line-100 w-full border-t" />
 
       <div className="flex w-full items-center gap-4">
         <InfoItem
@@ -159,7 +159,7 @@ export default function CardMyReview({
         />
       </div>
 
-      <hr className="w-full border-t" />
+      <hr className="border-line-100 w-full border-t" />
 
       {review}
 

--- a/src/component/common/card-my-review.tsx
+++ b/src/component/common/card-my-review.tsx
@@ -1,5 +1,6 @@
 import MoveTypeChip from "@/component/common/chip-move-type";
 import type { ServiceCode } from "@/component/common/chip-region";
+import InfoItem from "@/component/common/info-item";
 import MoverName from "@/component/common/mover-name";
 import ProfileAvatar from "@/component/common/profile-avatar";
 import RatingStars from "@/component/common/rating-stars";
@@ -25,36 +26,6 @@ interface CardMyReviewProps extends HTMLAttributes<HTMLElement> {
   content: string;
   /** 표시용으로 이미 포맷된 문자열 (예: "2024.07.02") - sm에서만 표시 */
   createdAt?: string;
-}
-
-/**
- * 이사 정보 한 쌍.
- * `MovingInfo`와 값이 달라(폰트・색・구분선) 이 카드 전용.
- */
-function InfoItem({
-  label,
-  value,
-  size,
-}: {
-  label: string;
-  value: string;
-  size: CardMyReviewSize;
-}) {
-  const isLg = size === "lg";
-
-  return (
-    <div className="win-w-0 flex flex-col items-start justify-center">
-      <span className={clsx("text-gray-gray-500", isLg ? "text-14" : "text-12")}>{label}</span>
-      <span
-        className={clsx(
-          "text-black-100 max-w-full truncate font-medium",
-          isLg ? "text-14" : "text-13"
-        )}
-      >
-        {value}
-      </span>
-    </div>
-  );
 }
 
 /** lg의 세로 구분선 */
@@ -109,7 +80,7 @@ export default function CardMyReview({
     return (
       <article className={cardClass} {...props}>
         <div className="flex w-full items-start gap-5">
-          <ProfileAvatar src={profileImage} alt={nickName} size="md" />
+          <ProfileAvatar src={profileImage} alt={nickName} size="80" />
 
           <div className="flex min-w-0 flex-1 flex-col items-start gap-2">
             <div className="flex w-full flex-col items-start justify-center">
@@ -123,11 +94,26 @@ export default function CardMyReview({
         </div>
 
         <div className="flex w-full items-center gap-5">
-          <InfoItem label="출발지" value={from} size={size} />
+          <InfoItem
+            label="출발지"
+            value={from}
+            labelClassName={isLg ? "text-14" : "text-12"}
+            valueClassName={clsx("text-black-100 font-medium", isLg ? "text-14" : "text-13")}
+          />
           <VerticalLine />
-          <InfoItem label="도착지" value={to} size={size} />
+          <InfoItem
+            label="도착지"
+            value={to}
+            labelClassName={isLg ? "text-14" : "text-12"}
+            valueClassName={clsx("text-black-100 font-medium", isLg ? "text-14" : "text-13")}
+          />
           <VerticalLine />
-          <InfoItem label="이사일" value={movingDate} size={size} />
+          <InfoItem
+            label="이사일"
+            value={movingDate}
+            labelClassName={isLg ? "text-14" : "text-12"}
+            valueClassName={clsx("text-black-100 font-medium", isLg ? "text-14" : "text-13")}
+          />
         </div>
 
         {review}
@@ -146,16 +132,31 @@ export default function CardMyReview({
 
         <div className="flex w-full items-center justify-between">
           <MoverName nickName={nickName} size="lg" />
-          <ProfileAvatar src={profileImage} alt={nickName} size="sm" />
+          <ProfileAvatar src={profileImage} alt={nickName} size="50" />
         </div>
       </div>
 
       <hr className="border-line-100 w-full border-t" />
 
       <div className="flex w-full items-center gap-4">
-        <InfoItem label="출발지" value={from} size={size} />
-        <InfoItem label="도착지" value={to} size={size} />
-        <InfoItem label="이사일" value={movingDate} size={size} />
+        <InfoItem
+          label="출발지"
+          value={from}
+          labelClassName={isLg ? "text-14" : "text-12"}
+          valueClassName={clsx("text-black-100 font-medium", isLg ? "text-14" : "text-13")}
+        />
+        <InfoItem
+          label="도착지"
+          value={to}
+          labelClassName={isLg ? "text-14" : "text-12"}
+          valueClassName={clsx("text-black-100 font-medium", isLg ? "text-14" : "text-13")}
+        />
+        <InfoItem
+          label="이사일"
+          value={movingDate}
+          labelClassName={isLg ? "text-14" : "text-12"}
+          valueClassName={clsx("text-black-100 font-medium", isLg ? "text-14" : "text-13")}
+        />
       </div>
 
       <hr className="border-line-100 w-full border-t" />

--- a/src/component/common/card-my-review.tsx
+++ b/src/component/common/card-my-review.tsx
@@ -60,8 +60,8 @@ export default function CardMyReview({
   const isLg = size === "lg";
 
   const cardClass = clsx(
-    "border-line-100 flex w-full flex-col border-[0.5px] bg-white",
-    "shadow-[-2px_-2px_10px_0_rgba(220,220,220,0.2),2px_2px_10px_0_rgba(220,220,220,0.2)]",
+    "flex w-full flex-col bg-white",
+    "shadow-[inset_0_0_0_0.5px_var(--color-line-100),-2px_-2px_10px_0_rgba(220,220,220,0.2),2px_2px_10px_0_rgba(220,220,220,0.2)]",
     "rounded-[20px]",
     isLg ? "gap-5 p-10" : "gap-4 px-5 py-6",
     className
@@ -131,12 +131,12 @@ export default function CardMyReview({
         </div>
 
         <div className="flex w-full items-center justify-between">
-          <MoverName nickName={nickName} size="lg" />
+          <MoverName nickName={nickName} size="lg" stacked />
           <ProfileAvatar src={profileImage} alt={nickName} size="50" />
         </div>
       </div>
 
-      <hr className="border-line-100 w-full border-t" />
+      <hr className="w-full border-t" />
 
       <div className="flex w-full items-center gap-4">
         <InfoItem
@@ -159,7 +159,7 @@ export default function CardMyReview({
         />
       </div>
 
-      <hr className="border-line-100 w-full border-t" />
+      <hr className="w-full border-t" />
 
       {review}
 

--- a/src/component/common/card-my-review.tsx
+++ b/src/component/common/card-my-review.tsx
@@ -97,14 +97,14 @@ export default function CardMyReview({
           <InfoItem
             label="출발지"
             value={from}
-            labelClassName={isLg ? "text-14" : "text-12"}
+            labelClassName={isLg ? "text-14" : "text-12 leading-[18px]"}
             valueClassName={clsx("text-black-100 font-medium", isLg ? "text-14" : "text-13")}
           />
           <VerticalLine />
           <InfoItem
             label="도착지"
             value={to}
-            labelClassName={isLg ? "text-14" : "text-12"}
+            labelClassName={isLg ? "text-14" : "text-12 leading-[18px]"}
             valueClassName={clsx("text-black-100 font-medium", isLg ? "text-14" : "text-13")}
           />
           <VerticalLine />
@@ -136,35 +136,35 @@ export default function CardMyReview({
         </div>
       </div>
 
-      <hr className="border-line-100 w-full border-t" />
+      <hr className="h-0 w-full border-0 shadow-[0_0_0_0.5px_var(--color-line-100)]" />
 
       <div className="flex w-full items-center gap-4">
         <InfoItem
           label="출발지"
           value={from}
-          labelClassName={isLg ? "text-14" : "text-12"}
+          labelClassName={isLg ? "text-14" : "text-12 leading-[18px]"}
           valueClassName={clsx("text-black-100 font-medium", isLg ? "text-14" : "text-13")}
         />
         <InfoItem
           label="도착지"
           value={to}
-          labelClassName={isLg ? "text-14" : "text-12"}
+          labelClassName={isLg ? "text-14" : "text-12 leading-[18px]"}
           valueClassName={clsx("text-black-100 font-medium", isLg ? "text-14" : "text-13")}
         />
         <InfoItem
           label="이사일"
           value={movingDate}
-          labelClassName={isLg ? "text-14" : "text-12"}
+          labelClassName={isLg ? "text-14" : "text-12 leading-[18px]"}
           valueClassName={clsx("text-black-100 font-medium", isLg ? "text-14" : "text-13")}
         />
       </div>
 
-      <hr className="border-line-100 w-full border-t" />
+      <hr className="h-0 w-full border-0 shadow-[0_0_0_0.5px_var(--color-line-100)]" />
 
       {review}
 
       {createdAt && (
-        <p className="text-12 text-gray-gray-300 flex w-full justify-end gap-1.5">
+        <p className="text-12 text-gray-gray-300 flex w-full justify-end gap-1.5 leading-4.5">
           <span>작성일</span>
           <span>{createdAt}</span>
         </p>

--- a/src/component/common/card-my-review.tsx
+++ b/src/component/common/card-my-review.tsx
@@ -61,7 +61,7 @@ export default function CardMyReview({
 
   const cardClass = clsx(
     "border-line-100 flex w-full flex-col border-[0.5px] bg-white",
-    "shadow-[-2px_-2px_10px_0_rgba(220,220,220,0.2),2px_2px_10px_0_rgba(220,220,220,0.2)",
+    "shadow-[-2px_-2px_10px_0_rgba(220,220,220,0.2),2px_2px_10px_0_rgba(220,220,220,0.2)]",
     "rounded-[20px]",
     isLg ? "gap-5 p-10" : "gap-4 px-5 py-6",
     className

--- a/src/component/common/card-my-review.tsx
+++ b/src/component/common/card-my-review.tsx
@@ -1,0 +1,173 @@
+import MoveTypeChip from "@/component/common/chip-move-type";
+import type { ServiceCode } from "@/component/common/chip-region";
+import MoverName from "@/component/common/mover-name";
+import ProfileAvatar from "@/component/common/profile-avatar";
+import RatingStars from "@/component/common/rating-stars";
+import clsx from "clsx";
+import type { HTMLAttributes } from "react";
+
+type CardMyReviewSize = "sm" | "lg";
+
+interface CardMyReviewProps extends HTMLAttributes<HTMLElement> {
+  size?: CardMyReviewSize;
+  category: ServiceCode;
+  /** 지정 견적 요청 여부 - sm에서만 칩으로 표시됨 */
+  isTargeted?: boolean;
+  nickName: string;
+  profileImage?: string | null;
+  /** 기사님 한 줄 소개 - lg에서만 표시 */
+  description?: string;
+  from: string;
+  to: string;
+  /** 표시용으로 이미 포맷된 문자열 */
+  movingDate: string;
+  rating: number;
+  content: string;
+  /** 표시용으로 이미 포맷된 문자열 (예: "2024.07.02") - sm에서만 표시 */
+  createdAt?: string;
+}
+
+/**
+ * 이사 정보 한 쌍.
+ * `MovingInfo`와 값이 달라(폰트・색・구분선) 이 카드 전용.
+ */
+function InfoItem({
+  label,
+  value,
+  size,
+}: {
+  label: string;
+  value: string;
+  size: CardMyReviewSize;
+}) {
+  const isLg = size === "lg";
+
+  return (
+    <div className="win-w-0 flex flex-col items-start justify-center">
+      <span className={clsx("text-gray-gray-500", isLg ? "text-14" : "text-12")}>{label}</span>
+      <span
+        className={clsx(
+          "text-black-100 max-w-full truncate font-medium",
+          isLg ? "text-14" : "text-13"
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+/** lg의 세로 구분선 */
+function VerticalLine() {
+  return <span aria-hidden className="bg-line-200 h-12.5 w-px shrink-0" />;
+}
+
+/**
+ * 내가 작성한 리뷰 카드.
+ * lg는 프로필이 왼쪽 가로 배치, sm은 칩이 위로 가고 프로필이 오른쪽으로 감.
+ *
+ * 폭은 부모가 정한다. (`w-full`)
+ *
+ * 사용법 : <CardMyReview size="lg" category="SMALL" nickName="김코드" rating={5} content="..." />
+ */
+export default function CardMyReview({
+  size = "sm",
+  category,
+  isTargeted = false,
+  nickName,
+  profileImage,
+  description,
+  from,
+  to,
+  movingDate,
+  rating,
+  content,
+  createdAt,
+  className,
+  ...props
+}: CardMyReviewProps) {
+  const isLg = size === "lg";
+
+  const cardClass = clsx(
+    "border-line-100 flex w-full flex-col border-[0.5px] bg-white",
+    "shadow-[-2px_-2px_10px_0_rgba(220,220,220,0.2),2px_2px_10px_0_rgba(220,220,220,0.2)",
+    "rounded-[20px]",
+    isLg ? "gap-5 p-10" : "gap-4 px-5 py-6",
+    className
+  );
+
+  const review = (
+    <div className="flex w-full flex-col items-start gap-3">
+      <RatingStars rating={rating} />
+      <p className={clsx("text-black-black-400 w-full font-medium", isLg ? "text-18" : "text-16")}>
+        {content}
+      </p>
+    </div>
+  );
+
+  if (isLg) {
+    return (
+      <article className={cardClass} {...props}>
+        <div className="flex w-full items-start gap-5">
+          <ProfileAvatar src={profileImage} alt={nickName} size="md" />
+
+          <div className="flex min-w-0 flex-1 flex-col items-start gap-2">
+            <div className="flex w-full flex-col items-start justify-center">
+              <MoverName nickName={nickName} size="xl" />
+              {description && (
+                <p className="text-14 text-gray-gray-500 w-full truncate">{description}</p>
+              )}
+            </div>
+            <MoveTypeChip variant={category} size="sm" />
+          </div>
+        </div>
+
+        <div className="flex w-full items-center gap-5">
+          <InfoItem label="출발지" value={from} size={size} />
+          <VerticalLine />
+          <InfoItem label="도착지" value={to} size={size} />
+          <VerticalLine />
+          <InfoItem label="이사일" value={movingDate} size={size} />
+        </div>
+
+        {review}
+      </article>
+    );
+  }
+
+  // sm - 칩이 맨 위, 프로필이 오른쪽
+  return (
+    <article className={cardClass} {...props}>
+      <div className="flex w-full flex-col items-start gap-3">
+        <div className="flex items-center gap-2">
+          <MoveTypeChip variant={category} size="sm" />
+          {isTargeted && <MoveTypeChip variant="TARGETED" size="sm" />}
+        </div>
+
+        <div className="flex w-full items-center justify-between">
+          <MoverName nickName={nickName} size="lg" />
+          <ProfileAvatar src={profileImage} alt={nickName} size="sm" />
+        </div>
+      </div>
+
+      <hr className="border-line-100 w-full border-t" />
+
+      <div className="flex w-full items-center gap-4">
+        <InfoItem label="출발지" value={from} size={size} />
+        <InfoItem label="도착지" value={to} size={size} />
+        <InfoItem label="이사일" value={movingDate} size={size} />
+      </div>
+
+      <hr className="border-line-100 w-full border-t" />
+
+      {review}
+
+      {createdAt && (
+        <p className="text-12 text-gray-gray-300 flex w-full justify-end gap-1.5">
+          <span>작성일</span>
+          <span>{createdAt}</span>
+        </p>
+      )}
+    </article>
+  );
+}

--- a/src/component/common/card-request.tsx
+++ b/src/component/common/card-request.tsx
@@ -86,7 +86,7 @@ export default function CardRequest({
             <span className="min-w-0 truncate">{customerName}</span>
             <span className="shrink-0">고객님</span>
           </p>
-          <hr className="border-line-100 w-full border-t" />
+          <hr className="h-0 w-full border-0 shadow-[0_0_0_0.5px_var(--color-line-100)]" />
         </div>
 
         <MovingInfo from={from} to={to} movingDate={movingDate} size={size} />

--- a/src/component/common/card-request.tsx
+++ b/src/component/common/card-request.tsx
@@ -86,7 +86,7 @@ export default function CardRequest({
             <span className="min-w-0 truncate">{customerName}</span>
             <span className="shrink-0">고객님</span>
           </p>
-          <hr className="w-full border-t" />
+          <hr className="border-line-100 w-full border-t" />
         </div>
 
         <MovingInfo from={from} to={to} movingDate={movingDate} size={size} />

--- a/src/component/common/card-request.tsx
+++ b/src/component/common/card-request.tsx
@@ -57,8 +57,8 @@ export default function CardRequest({
   return (
     <article
       className={clsx(
-        "border-line-100 relative flex flex-col items-start border-[0.5px] bg-white",
-        "shadow-[-2px_-2px_10px_0_rgba(220,220,220,0.2),2px_2px_10px_0_rgba(220,220,220,0.2)]",
+        "relative flex flex-col items-start bg-white",
+        "shadow-[inset_0_0_0_0.5px_var(--color-line-100),-2px_-2px_10px_0_rgba(220,220,220,0.2),2px_2px_10px_0_rgba(220,220,220,0.2)]",
         "w-full",
         isLg ? "gap-8 rounded-[20px] px-10 py-8" : "gap-6 rounded-[20px] px-5 py-6",
         className
@@ -86,7 +86,7 @@ export default function CardRequest({
             <span className="min-w-0 truncate">{customerName}</span>
             <span className="shrink-0">고객님</span>
           </p>
-          <hr className="border-line-100 w-full border-t" />
+          <hr className="w-full border-t" />
         </div>
 
         <MovingInfo from={from} to={to} movingDate={movingDate} size={size} />

--- a/src/component/common/card-review.tsx
+++ b/src/component/common/card-review.tsx
@@ -1,0 +1,72 @@
+import RatingStars from "@/component/common/rating-stars";
+import clsx from "clsx";
+import type { HTMLAttributes } from "react";
+
+type CardReviewSize = "sm" | "lg";
+
+interface CardReviewProps extends HTMLAttributes<HTMLElement> {
+  size?: CardReviewSize;
+  /** 마스킹된 작성자 아이딛 (예: "kim****") */
+  writer: string;
+  /** 표시용으로 이미 포맷된 문자열 (예: "2024-07-01") */
+  createdAt: string;
+  rating: number;
+  content: string;
+}
+
+/** 작성자와 날짜를 나누는 세로 구분선 */
+function Divider({ size }: { size: CardReviewSize }) {
+  return (
+    <span
+      aria-hidden
+      className={clsx("bg-line-200 w-px shrink-0", size === "lg" ? "h-3.5" : "h-3")}
+    />
+  );
+}
+
+/**
+ * 기사님 상세 페이지의 리뷰 목록 행.
+ * 테두리・그림자가 없고 세로로 이어 붙는 형태.
+ *
+ * 폭은 부모가 정함 (`w-full`). Button・Input과 같은 방식.
+ *
+ * 사용법 : <CardReview size="lg" writer="kim****" createdAt="2024-07-01" rating={5} content="..." />
+ */
+export default function CardReview({
+  size = "sm",
+  writer,
+  createdAt,
+  rating,
+  content,
+  className,
+  ...props
+}: CardReviewProps) {
+  const isLg = size === "lg";
+
+  return (
+    <article
+      className={clsx(
+        "flex w-full flex-col items-start bg-white",
+        isLg ? "gap-6 py-6" : "gap-4 py-5",
+        className
+      )}
+      {...props}
+    >
+      <div className="flex flex-col items-start gap-2">
+        <div className={clsx("flex items-center", isLg ? "gap-3.5" : "gap-3")}>
+          <span className={clsx("text-black-black-400", isLg ? "text-18" : "text-14")}>
+            {writer}
+          </span>
+          <Divider size={size} />
+          <span className={clsx("text-gray-gray-300", isLg ? "text-18" : "text-14")}>
+            {createdAt}
+          </span>
+        </div>
+
+        <RatingStars rating={rating} />
+      </div>
+
+      <p className={clsx("text-black-500 w-full", isLg ? "text-18" : "text-14")}>{content}</p>
+    </article>
+  );
+}

--- a/src/component/common/card-writable-review.tsx
+++ b/src/component/common/card-writable-review.tsx
@@ -68,8 +68,8 @@ export default function CardWritableReview({
   const isSm = size === "sm";
 
   const cardClass = clsx(
-    "border-line-100 flex w-full flex-col border-[0.5px] bg-white",
-    "shadow-[-2px_-2px_10px_0_rgba(220,220,220,0.2),2px_2px_10px_0_rgba(220,220,220,0.2)]",
+    "flex w-full flex-col bg-white",
+    "shadow-[inset_0_0_0_0.5px_var(--color-line-100),-2px_-2px_10px_0_rgba(220,220,220,0.2),2px_2px_10px_0_rgba(220,220,220,0.2)]",
     "rounded-[20px]",
     isLg && "gap-6 px-10 py-8",
     isMd && "gap-10 p-8",
@@ -131,7 +131,7 @@ export default function CardWritableReview({
   if (isMd) {
     return (
       <article className={cardClass} {...props}>
-        <div className="flex w-full flex-col gap-7">
+        <div className="flex w-full flex-col gap-6">
           <div className="flex w-full items-start gap-5">
             <ProfileAvatar src={profileImage} alt={nickName} size="80" />
 
@@ -170,37 +170,40 @@ export default function CardWritableReview({
   /* ── sm (327px) ──────────────────────────────────── */
   return (
     <article className={cardClass} {...props}>
+      {/* 피그마는 카드(gap 20)와 내용(gap 12)이 두 층입니다 — 1:12199 */}
       <div className="flex w-full flex-col items-start gap-3">
-        <div className="flex items-center gap-2">
-          <MoveTypeChip variant={category} size="sm" />
-          {isTargeted && <MoveTypeChip variant="TARGETED" size="sm" />}
-        </div>
-
-        <div className="flex w-full items-center gap-2">
-          <div className="flex min-w-0 flex-1 flex-col items-start gap-1">
-            <MoverName nickName={nickName} size="lg" />
-            {description && (
-              <p className="text-12 text-gray-gray-500 w-full truncate">{description}</p>
-            )}
+        <div className="flex w-full flex-col items-start gap-3">
+          <div className="flex items-center gap-2">
+            <MoveTypeChip variant={category} size="sm" />
+            {isTargeted && <MoveTypeChip variant="TARGETED" size="sm" />}
           </div>
-          <ProfileAvatar src={profileImage} alt={nickName} size="64" />
-        </div>
-      </div>
 
-      {/* sm은 이사 정보가 2행 (출발지·도착지 / 이사일) */}
-      <div className="flex w-full flex-col items-start justify-center gap-4">
-        <div className="flex w-full items-center gap-4">
-          <InfoItem label="출발지" value={from} valueClassName={infoValueClass} />
-          <InfoItem label="도착지" value={to} valueClassName={infoValueClass} />
+          <div className="flex w-full items-center gap-2">
+            <div className="flex min-w-0 flex-1 flex-col items-start gap-1">
+              <MoverName nickName={nickName} size="lg" stacked />
+              {description && (
+                <p className="text-12 text-gray-gray-500 w-full truncate">{description}</p>
+              )}
+            </div>
+            <ProfileAvatar src={profileImage} alt={nickName} size="64" />
+          </div>
         </div>
-        <InfoItem label="이사일" value={movingDate} valueClassName={infoValueClass} />
-      </div>
 
-      <div className="border-line-200 flex h-11.75 w-full items-end justify-between border-t">
-        <span className="text-14 text-gray-gray-300 font-medium">견적 금액</span>
-        <span className="text-18 text-black-black-400 font-bold whitespace-nowrap">
-          {price.toLocaleString()}원
-        </span>
+        {/* sm은 이사 정보가 2행 (출발지·도착지 / 이사일) */}
+        <div className="flex w-full flex-col items-start justify-center gap-4">
+          <div className="flex w-full items-center gap-4">
+            <InfoItem label="출발지" value={from} valueClassName={infoValueClass} />
+            <InfoItem label="도착지" value={to} valueClassName={infoValueClass} />
+          </div>
+          <InfoItem label="이사일" value={movingDate} valueClassName={infoValueClass} />
+        </div>
+
+        <div className="border-line-200 flex h-11.75 w-full items-end justify-between border-t">
+          <span className="text-14 text-gray-gray-300 font-medium">견적 금액</span>
+          <span className="text-18 text-black-black-400 font-bold whitespace-nowrap">
+            {price.toLocaleString()}원
+          </span>
+        </div>
       </div>
 
       {writeButton}

--- a/src/component/common/card-writable-review.tsx
+++ b/src/component/common/card-writable-review.tsx
@@ -73,7 +73,7 @@ export default function CardWritableReview({
     "rounded-[20px]",
     isLg && "gap-6 px-10 py-8",
     isMd && "gap-10 p-8",
-    isSm && "gap-5 px-5 py-6",
+    isSm && "gap-5 px-5 py-5",
     className
   );
 

--- a/src/component/common/card-writable-review.tsx
+++ b/src/component/common/card-writable-review.tsx
@@ -73,7 +73,7 @@ export default function CardWritableReview({
     "rounded-[20px]",
     isLg && "gap-6 px-10 py-8",
     isMd && "gap-10 p-8",
-    isSm && "gap-5 px-5 py-5",
+    isSm && "gap-5 px-5 py-6",
     className
   );
 
@@ -179,10 +179,12 @@ export default function CardWritableReview({
           </div>
 
           <div className="flex w-full items-center gap-2">
-            <div className="flex min-w-0 flex-1 flex-col items-start gap-1">
+            <div className="flex min-w-0 flex-1 flex-col items-start">
               <MoverName nickName={nickName} size="lg" stacked />
               {description && (
-                <p className="text-12 text-gray-gray-500 w-full truncate">{description}</p>
+                <p className="text-12 text-gray-gray-500 w-full truncate leading-4.5">
+                  {description}
+                </p>
               )}
             </div>
             <ProfileAvatar src={profileImage} alt={nickName} size="64" />

--- a/src/component/common/card-writable-review.tsx
+++ b/src/component/common/card-writable-review.tsx
@@ -1,0 +1,209 @@
+import Button from "@/component/common/button";
+import MoveTypeChip from "@/component/common/chip-move-type";
+import type { ServiceCode } from "@/component/common/chip-region";
+import InfoItem from "@/component/common/info-item";
+import MoverName from "@/component/common/mover-name";
+import ProfileAvatar from "@/component/common/profile-avatar";
+import clsx from "clsx";
+import type { HTMLAttributes } from "react";
+
+type CardWritableReviewSize = "sm" | "md" | "lg";
+
+interface CardWritableReviewProps extends HTMLAttributes<HTMLElement> {
+  size?: CardWritableReviewSize;
+  category: ServiceCode;
+  /** 지정 견적 요청 여부 — sm에서만 칩으로 표시됩니다 */
+  isTargeted?: boolean;
+  nickName: string;
+  profileImage?: string | null;
+  /** 기사님 한 줄 소개 */
+  description?: string;
+  from: string;
+  to: string;
+  /** 표시용으로 이미 포맷된 문자열 */
+  movingDate: string;
+  price: number;
+  /** 이미 리뷰를 썼거나 작성 기간이 지나면 버튼이 비활성화됩니다 */
+  disabled?: boolean;
+  onWriteClick?: () => void;
+}
+
+/** lg·md의 세로 구분선 */
+function VerticalLine() {
+  return <span aria-hidden className="bg-line-200 h-12.5 w-px shrink-0" />;
+}
+
+/**
+ * 작성 가능한 리뷰 카드.
+ * 사이즈별로 프로필 크기(100/80/64)와 금액 위치가 다릅니다.
+ * - lg: 금액이 우측 상단, 버튼 160px
+ * - md: 금액이 이사 정보와 같은 줄, 버튼 w-full
+ * - sm: 칩이 맨 위, 금액이 구분선 아래, 버튼 w-full
+ *
+ * 피그마의 `sort=disabled`는 별도 레이아웃이 아니라 **버튼 상태**입니다.
+ * 기존 Button의 `disabled:bg-gray-300`이 피그마 `#D9D9D9`와 같습니다.
+ *
+ * **폭은 부모가 정합니다** (`w-full`).
+ *
+ * 사용법: <CardWritableReview size="lg" category="SMALL" nickName="김코드" price={180000} />
+ */
+export default function CardWritableReview({
+  size = "sm",
+  category,
+  isTargeted = false,
+  nickName,
+  profileImage,
+  description,
+  from,
+  to,
+  movingDate,
+  price,
+  disabled = false,
+  onWriteClick,
+  className,
+  ...props
+}: CardWritableReviewProps) {
+  const isLg = size === "lg";
+  const isMd = size === "md";
+  const isSm = size === "sm";
+
+  const cardClass = clsx(
+    "border-line-100 flex w-full flex-col border-[0.5px] bg-white",
+    "shadow-[-2px_-2px_10px_0_rgba(220,220,220,0.2),2px_2px_10px_0_rgba(220,220,220,0.2)]",
+    "rounded-[20px]",
+    isLg && "gap-6 px-10 py-8",
+    isMd && "gap-10 p-8",
+    isSm && "gap-5 px-5 py-6",
+    className
+  );
+
+  // 이사 정보 값 — lg·md는 16, sm은 14. 셋 다 regular
+  const infoValueClass = clsx("text-black-500", isSm ? "text-14" : "text-16");
+
+  const writeButton = (
+    <Button variant="solid" size="sm" disabled={disabled} onClick={onWriteClick}>
+      리뷰 작성하기
+    </Button>
+  );
+
+  /* ── lg (1120px) ─────────────────────────────────── */
+  if (isLg) {
+    return (
+      <article className={cardClass} {...props}>
+        <div className="flex w-full items-end gap-6">
+          <ProfileAvatar src={profileImage} alt={nickName} size="100" />
+
+          <div className="flex min-w-0 flex-1 items-end gap-2">
+            <div className="flex min-w-0 flex-1 flex-col items-start gap-2">
+              <div className="flex w-full flex-col items-start justify-center">
+                <MoverName nickName={nickName} size="xl" />
+                {description && (
+                  <p className="text-14 text-gray-gray-500 w-full truncate">{description}</p>
+                )}
+              </div>
+              <MoveTypeChip variant={category} size="md" />
+            </div>
+
+            <div className="flex w-40 shrink-0 flex-col items-end">
+              <span className="text-16 text-gray-gray-500 font-medium">견적 금액</span>
+              <span className="text-24 text-black-black-400 font-bold whitespace-nowrap">
+                {price.toLocaleString()}원
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex w-full items-center justify-between gap-5">
+          <div className="flex min-w-0 items-center gap-5">
+            <InfoItem label="출발지" value={from} valueClassName={infoValueClass} />
+            <VerticalLine />
+            <InfoItem label="도착지" value={to} valueClassName={infoValueClass} />
+            <VerticalLine />
+            <InfoItem label="이사일" value={movingDate} valueClassName={infoValueClass} />
+          </div>
+          <div className="w-40 shrink-0">{writeButton}</div>
+        </div>
+      </article>
+    );
+  }
+
+  /* ── md (600px) ──────────────────────────────────── */
+  if (isMd) {
+    return (
+      <article className={cardClass} {...props}>
+        <div className="flex w-full flex-col gap-7">
+          <div className="flex w-full items-start gap-5">
+            <ProfileAvatar src={profileImage} alt={nickName} size="80" />
+
+            <div className="flex min-w-0 flex-1 flex-col items-start gap-2">
+              <div className="flex w-full flex-col items-start justify-center">
+                <MoverName nickName={nickName} size="xl" />
+                {description && (
+                  <p className="text-14 text-gray-gray-500 w-full truncate">{description}</p>
+                )}
+              </div>
+              <MoveTypeChip variant={category} size="sm" />
+            </div>
+          </div>
+
+          {/* md는 금액이 이사 정보와 같은 줄입니다 */}
+          <div className="flex w-full items-center gap-4">
+            <InfoItem label="출발지" value={from} valueClassName={infoValueClass} />
+            <InfoItem label="도착지" value={to} valueClassName={infoValueClass} />
+            <VerticalLine />
+            <InfoItem label="이사일" value={movingDate} valueClassName={infoValueClass} />
+            <VerticalLine />
+            <div className="flex shrink-0 flex-col items-end">
+              <span className="text-14 text-gray-gray-500">견적금액</span>
+              <span className="text-18 text-black-black-400 font-bold whitespace-nowrap">
+                {price.toLocaleString()}원
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {writeButton}
+      </article>
+    );
+  }
+
+  /* ── sm (327px) ──────────────────────────────────── */
+  return (
+    <article className={cardClass} {...props}>
+      <div className="flex w-full flex-col items-start gap-3">
+        <div className="flex items-center gap-2">
+          <MoveTypeChip variant={category} size="sm" />
+          {isTargeted && <MoveTypeChip variant="TARGETED" size="sm" />}
+        </div>
+
+        <div className="flex w-full items-center gap-2">
+          <div className="flex min-w-0 flex-1 flex-col items-start gap-1">
+            <MoverName nickName={nickName} size="lg" />
+            {description && (
+              <p className="text-12 text-gray-gray-500 w-full truncate">{description}</p>
+            )}
+          </div>
+          <ProfileAvatar src={profileImage} alt={nickName} size="64" />
+        </div>
+      </div>
+
+      {/* sm은 이사 정보가 2행 (출발지·도착지 / 이사일) */}
+      <div className="flex w-full flex-col items-start justify-center gap-4">
+        <div className="flex w-full items-center gap-4">
+          <InfoItem label="출발지" value={from} valueClassName={infoValueClass} />
+          <InfoItem label="도착지" value={to} valueClassName={infoValueClass} />
+        </div>
+        <InfoItem label="이사일" value={movingDate} valueClassName={infoValueClass} />
+      </div>
+
+      <div className="border-line-200 flex h-11.75 w-full items-end justify-between border-t">
+        <span className="text-14 text-gray-gray-300 font-medium">견적 금액</span>
+        <span className="text-18 text-black-black-400 font-bold whitespace-nowrap">
+          {price.toLocaleString()}원
+        </span>
+      </div>
+
+      {writeButton}
+    </article>
+  );
+}

--- a/src/component/common/info-item.tsx
+++ b/src/component/common/info-item.tsx
@@ -1,0 +1,38 @@
+import clsx from "clsx";
+
+interface InfoItemProps {
+  label: string;
+  value: string;
+  /** 라벨 크기 — 기본 text-14 */
+  labelClassName?: string;
+  /** 값의 크기·색·굵기 — 카드마다 달라 호출부가 정합니다 */
+  valueClassName?: string;
+  className?: string;
+}
+
+/**
+ * 이사 정보 한 쌍(라벨 + 값). Card-list 리뷰 계열이 공유합니다.
+ *
+ * 값의 스타일이 카드마다 달라 클래스를 호출부에서 받습니다.
+ * - 내가 작성한 리뷰: `text-14/13 black-100 medium`
+ * - 작성 가능한 리뷰: `text-16/14 black-500 regular`
+ *
+ * (`MovingInfo`는 `text-16 black-500 semibold`에 화살표 아이콘이 들어가는
+ *  별도 컴포넌트입니다. 고객 견적·받은 요청 계열과 리뷰쓰기 모달이 씁니다.)
+ *
+ * 사용법: <InfoItem label="출발지" value="서울시 중구" valueClassName="text-16 text-black-500" />
+ */
+export default function InfoItem({
+  label,
+  value,
+  labelClassName = "text-14",
+  valueClassName,
+  className,
+}: InfoItemProps) {
+  return (
+    <div className={clsx("flex min-w-0 flex-col items-start justify-center", className)}>
+      <span className={clsx("text-gray-gray-500", labelClassName)}>{label}</span>
+      <span className={clsx("max-w-full truncate", valueClassName)}>{value}</span>
+    </div>
+  );
+}

--- a/src/component/common/mover-name.tsx
+++ b/src/component/common/mover-name.tsx
@@ -3,15 +3,23 @@ import clsx from "clsx";
 import Image from "next/image";
 import type { HTMLAttributes } from "react";
 
-type MoverNameSize = "sm" | "md" | "lg";
+type MoverNameSize = "sm" | "md" | "lg" | "xl";
 
 interface MoverNameProps extends HTMLAttributes<HTMLDivElement> {
   nickName: string;
-  /** lg는 text-16, 나머지는 text-14 */
+  /** sm·md 14 / lg 16 / xl 18(bold) */
   size?: MoverNameSize;
   /** 견적내역 카드 lg처럼 로고 없이 이름만 쓰는 곳이 있습니다 */
   showLogo?: boolean;
 }
+
+// xl은 "내가 작성한 리뷰" lg에서만 씁니다 (피그마 1:12482 — 유일하게 bold)
+const SIZE_CLASS: Record<MoverNameSize, string> = {
+  sm: "text-14 font-semibold",
+  md: "text-14 font-semibold",
+  lg: "text-16 font-semibold",
+  xl: "text-18 font-bold",
+};
 
 // 사용법: <MoverName nickName="김코드" size="lg" />
 export default function MoverName({
@@ -26,8 +34,8 @@ export default function MoverName({
       {showLogo && <Image src={logoMark} alt="" className="h-5.75 w-5 shrink-0" />}
       <span
         className={clsx(
-          "text-black-300 flex items-center gap-1 font-semibold whitespace-nowrap",
-          size === "lg" ? "text-16" : "text-14"
+          "text-black-300 flex items-center gap-1 whitespace-nowrap",
+          SIZE_CLASS[size]
         )}
       >
         <span>{nickName}</span>

--- a/src/component/common/mover-name.tsx
+++ b/src/component/common/mover-name.tsx
@@ -11,6 +11,8 @@ interface MoverNameProps extends HTMLAttributes<HTMLDivElement> {
   size?: MoverNameSize;
   /** 견적내역 카드 lg처럼 로고 없이 이름만 쓰는 곳이 있습니다 */
   showLogo?: boolean;
+  /** 로고를 이름 위에 세로로 배치 — 리뷰 카드 sm (피그마 1:12520) */
+  stacked?: boolean;
 }
 
 // xl은 "내가 작성한 리뷰" lg에서만 씁니다 (피그마 1:12482 — 유일하게 bold)
@@ -26,11 +28,15 @@ export default function MoverName({
   nickName,
   size = "sm",
   showLogo = true,
+  stacked = false,
   className,
   ...props
 }: MoverNameProps) {
   return (
-    <div className={clsx("flex items-center gap-1", className)} {...props}>
+    <div
+      className={clsx("flex gap-1", stacked ? "flex-col items-start" : "items-center", className)}
+      {...props}
+    >
       {showLogo && <Image src={logoMark} alt="" className="h-5.75 w-5 shrink-0" />}
       <span
         className={clsx(

--- a/src/component/common/mover-name.tsx
+++ b/src/component/common/mover-name.tsx
@@ -37,7 +37,13 @@ export default function MoverName({
       className={clsx("flex gap-1", stacked ? "flex-col items-start" : "items-center", className)}
       {...props}
     >
-      {showLogo && <Image src={logoMark} alt="" className="h-5.75 w-5 shrink-0" />}
+      {showLogo && (
+        <Image
+          src={logoMark}
+          alt={logoMark}
+          className="pc:h-5.75 tablet:h-5.75 h-[18.2px] w-5 shrink-0"
+        />
+      )}
       <span
         className={clsx(
           "text-black-300 flex items-center gap-1 whitespace-nowrap",

--- a/src/component/common/profile-avatar.tsx
+++ b/src/component/common/profile-avatar.tsx
@@ -3,7 +3,7 @@ import profile50 from "@/assets/images/common/프로필_50.png";
 import clsx from "clsx";
 import Image, { type StaticImageData } from "next/image";
 
-type ProfileAvatarSize = "sm" | "lg";
+type ProfileAvatarSize = "sm" | "md" | "lg";
 
 interface ProfileAvatarProps {
   /** 프로필 이미지 URL. 없으면 기본 아이콘으로 표시 */
@@ -13,13 +13,23 @@ interface ProfileAvatarProps {
   className?: string;
 }
 
+// 피그마 profile(1:4445)은 50/64/80/100/140 5종. 카드에 쓰이는 것만 구현합니다
 const SIZE_CLASS: Record<ProfileAvatarSize, string> = {
   sm: "size-12.5",
+  md: "size-20",
   lg: "size-33.5",
 };
 
+const SIZE_PX: Record<ProfileAvatarSize, string> = {
+  sm: "50px",
+  md: "80px",
+  lg: "134px",
+};
+
+// md(80px)용 기본 이미지가 따로 없어 140을 줄여 씁니다 (50을 키우면 깨집니다)
 const FALLBACK_IMAGE: Record<ProfileAvatarSize, StaticImageData> = {
   sm: profile50,
+  md: profile140,
   lg: profile140,
 };
 
@@ -42,7 +52,7 @@ export default function ProfileAvatar({
         src={src || FALLBACK_IMAGE[size]}
         alt={alt}
         fill
-        sizes={size === "lg" ? "134px" : "50px"}
+        sizes={SIZE_PX[size]}
         className="object-cover"
       />
     </div>

--- a/src/component/common/profile-avatar.tsx
+++ b/src/component/common/profile-avatar.tsx
@@ -3,7 +3,12 @@ import profile50 from "@/assets/images/common/프로필_50.png";
 import clsx from "clsx";
 import Image, { type StaticImageData } from "next/image";
 
-type ProfileAvatarSize = "sm" | "md" | "lg";
+/**
+ * 피그마 profile(1:4445)의 크기를 그대로 씁니다.
+ * sm/md/lg 대신 픽셀값을 쓰는 이유는, 같은 "lg"라도 카드마다 크기가 달라
+ * 이름으로는 어느 카드의 lg인지 알 수 없기 때문입니다.
+ */
+type ProfileAvatarSize = "50" | "64" | "80" | "100" | "134";
 
 interface ProfileAvatarProps {
   /** 프로필 이미지 URL. 없으면 기본 아이콘으로 표시 */
@@ -13,31 +18,36 @@ interface ProfileAvatarProps {
   className?: string;
 }
 
-// 피그마 profile(1:4445)은 50/64/80/100/140 5종. 카드에 쓰이는 것만 구현합니다
 const SIZE_CLASS: Record<ProfileAvatarSize, string> = {
-  sm: "size-12.5",
-  md: "size-20",
-  lg: "size-33.5",
+  "50": "size-12.5",
+  "64": "size-16",
+  "80": "size-20",
+  "100": "size-25",
+  "134": "size-33.5",
 };
 
 const SIZE_PX: Record<ProfileAvatarSize, string> = {
-  sm: "50px",
-  md: "80px",
-  lg: "134px",
+  "50": "50px",
+  "64": "64px",
+  "80": "80px",
+  "100": "100px",
+  "134": "134px",
 };
 
-// md(80px)용 기본 이미지가 따로 없어 140을 줄여 씁니다 (50을 키우면 깨집니다)
+// 50 외에는 기본 이미지가 따로 없어 140을 줄여 씁니다 (50을 키우면 깨집니다)
 const FALLBACK_IMAGE: Record<ProfileAvatarSize, StaticImageData> = {
-  sm: profile50,
-  md: profile140,
-  lg: profile140,
+  "50": profile50,
+  "64": profile140,
+  "80": profile140,
+  "100": profile140,
+  "134": profile140,
 };
 
-// 사용법: <ProfileAvatar src={mover.image} alt={mover.nickName} size="lg" />
+// 사용법: <ProfileAvatar src={mover.image} alt={mover.nickName} size="134" />
 export default function ProfileAvatar({
   src,
   alt = "프로필이미지",
-  size = "sm",
+  size = "50",
   className,
 }: ProfileAvatarProps) {
   return (

--- a/src/component/common/quote-action-modal.tsx
+++ b/src/component/common/quote-action-modal.tsx
@@ -101,7 +101,9 @@ export default function QuoteActionModal({
             size={isMd ? "lg" : "sm"}
           />
 
-          {isMd && <hr className="border-line-100 w-full border-t" />}
+          {isMd && (
+            <hr className="h-0 w-full border-0 shadow-[0_0_0_0.5px_var(--color-line-100)]" />
+          )}
         </div>
 
         <div className="flex w-full flex-col items-start gap-4">

--- a/src/component/common/rating-stars.tsx
+++ b/src/component/common/rating-stars.tsx
@@ -1,0 +1,41 @@
+import starActive from "@/assets/icons/star-sm-active.svg";
+import starDefault from "@/assets/icons/star-sm-default.svg";
+import clsx from "clsx";
+import Image from "next/image";
+
+const MAX_RATING = 5;
+
+interface RatingStarsProps {
+  /** 0~5. 소수점은 반올림해서 채운 별 개수를 정한다 */
+  rating: number;
+  className?: string;
+}
+
+/**
+ * 별점 표시 (별 5개). 리뷰 카드 계열이 공유.
+ *
+ * 피그마는 별을 gap 없이 붙여 놓음. (20px x 5 = 100px).
+ * 별점 입력(클릭)은 모달 담당자 몫이라 여기서는 표시 전용.
+ *
+ * 사용법 : <RatingStars rating={5} />
+ */
+export default function RatingStars({ rating, className }: RatingStarsProps) {
+  const filled = Math.round(rating);
+
+  return (
+    <div
+      className={clsx("flex items-start", className)}
+      role="img"
+      aria-label={`별점 ${rating}점 (5점 만점)`}
+    >
+      {Array.from({ length: MAX_RATING }, (_, i) => (
+        <Image
+          key={i}
+          src={i < filled ? starActive : starDefault}
+          alt=""
+          className="size-5 shrink-0"
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/component/common/review-write-modal.tsx
+++ b/src/component/common/review-write-modal.tsx
@@ -86,7 +86,7 @@ export default function ReviewWriteModal({
             <ProfileAvatar src={moverProfileImage} alt={moverNickName} size="50" />
           </div>
 
-          <hr className="border-line-100 w-full border-t" />
+          <hr className="h-0 w-full border-0 shadow-[0_0_0_0.5px_var(--color-line-100)]" />
 
           <MovingInfo
             from={fromAddress}
@@ -95,7 +95,7 @@ export default function ReviewWriteModal({
             size={isMd ? "lg" : "sm"}
           />
 
-          <hr className="border-line-100 w-full border-t" />
+          <hr className="h-0 w-full border-0 shadow-[0_0_0_0.5px_var(--color-line-100)]" />
         </div>
 
         <div className="flex w-full flex-col items-start gap-3">

--- a/src/component/common/review-write-modal.tsx
+++ b/src/component/common/review-write-modal.tsx
@@ -83,7 +83,7 @@ export default function ReviewWriteModal({
 
           <div className="flex w-full items-center justify-between">
             <MoverName nickName={moverNickName} size={isMd ? "md" : "sm"} />
-            <ProfileAvatar src={moverProfileImage} alt={moverNickName} size="sm" />
+            <ProfileAvatar src={moverProfileImage} alt={moverNickName} size="50" />
           </div>
 
           <hr className="border-line-100 w-full border-t" />


### PR DESCRIPTION
## 📌 개요

- 공통 컴포넌트 Card-list 중 **리뷰 계열 3종**을 구현했습니다.
Card-list-review · 내가 작성한 리뷰 · 작성 가능한 리뷰이며, 카드별로 필요한 사이즈를 모두 지원합니다.

#47(PR #48)에서 만든 공통 조각을 재사용했고, 3종이 공유하는 **별점 표시**와 **이사 정보 항목**을 새로 분리했습니다.

이로써 **Card-list 10종이 모두 완료**됐습니다.

## 🔢 Linked Issue

- close #51 

## 🛠️ 주요 변경 사항

### 카드 3종 (`feat`)

- [x] `card-review.tsx` — Card-list-review (lg 955 / sm 600)
- [x] `card-my-review.tsx` — 내가 작성한 리뷰 (lg 588·1120 / sm 327)
- [x] `card-writable-review.tsx` — 작성 가능한 리뷰 (lg 1120 / md 600 / sm 327 × default·disabled)

### 재사용 조각 분리 (`feat`)

- [x] `rating-stars.tsx` — 별점 5개 **(3종 공용)**
- [x] `info-item.tsx` — 이사 정보 라벨+값 **(리뷰 카드 2종 공용)**

### ⚠️ `ProfileAvatar` 사이즈 체계 전환 — **Breaking Change**

```
- size="sm" | "md" | "lg"
+ size="50" | "64" | "80" | "100" | "134"
```

**다른 분이 `size="lg"` 등으로 쓰고 계시면 타입 에러가 납니다.** 이번 PR에서 기존 호출부 6곳은 모두 수정했습니다.

> 🔗 PR #58(Modal/Pop-up) 머지 후 rebase하면서 리뷰쓰기 모달의 `size="sm"` → `"50"`도 함께 수정했습니다. @MunChiho

<details>
<summary>왜 픽셀값으로 바꿨나</summary>

작성 가능한 리뷰가 **100px·64px**을 쓰는데 기존은 50/80/134 3종뿐이었습니다.

이름 기반으로 추가하면 `lg`(134)보다 작은 `xl`(100)이 생겨 어느 쪽이 큰지 알 수 없게 됩니다. 카드마다 "lg"가 가리키는 크기가 달라서 생기는 문제라, 피그마 `profile`(`1:4445`) 값을 그대로 쓰는 쪽이 명확하다고 판단했습니다.

> 피그마 컴포넌트는 140이지만 기사님 찾기 카드에서 **134로 리사이즈**해 쓰고 있어(`1:12569`) 134로 넣었습니다.

</details>

### 기존 파일 수정

| 파일 | 변경 | 영향 |
|---|---|---|
| `profile-avatar.tsx` | 사이즈 체계 전환 (위 참조) | **호출부 수정 필요** |
| `mover-name.tsx` | `xl`(18px bold) 추가 | 없음 — 추가만 |
| `card-mover.tsx` | ProfileAvatar 호출 3곳 | 표시 동일 |
| `card-estimate.tsx` | ProfileAvatar 호출 1곳 | 표시 동일 |

## 📸 스크린샷 (선택)
<details>
<summary>card-list-review</summary>
<img width="1827" height="184" alt="SCR-20260910-qxhc" src="https://github.com/user-attachments/assets/1091c429-aa4b-43dd-9977-52d78509ab60" />
</details>

<details>
<summary>내가 작성한 리뷰</summary>
<img width="1740" height="414" alt="SCR-20260910-qxij" src="https://github.com/user-attachments/assets/cb467f2c-f574-4fa8-968c-7791894a51a5" />
</details>

<details>
<summary>작성 가능한 리뷰</summary>
<img width="1856" height="615" alt="SCR-20260910-qxjr" src="https://github.com/user-attachments/assets/73605532-f90d-4f6e-8206-4ead99fadaa0" />
</details>

## 🧪 테스트 결과 & 리뷰 요청 사항

- `tsc --noEmit` / `eslint` / `prettier --check` 통과
- 확인 페이지: `/component-card-list` 하단 3개 섹션
- 피그마와 카드별로 대조했습니다 (lg/md/sm, default/disabled)

### 설계 판단 — 공유드립니다

**① `MovingInfo`를 쓰지 않았습니다**

출발지·도착지·이사일 블록이라 재사용하려 했는데, 값이 카드마다 달랐습니다.

| | 라벨 | 값 |
|---|---|---|
| `MovingInfo` | 14 | `16 black-500 **semibold**` + 화살표 |
| 내가 작성한 리뷰 | 14 / 12 | `14·13 **black-100 medium**` |
| 작성 가능한 리뷰 | 14 | `16·14 black-500 **regular**` |

`MovingInfo`는 고객 견적·받은 요청 계열 4종과 치호님 리뷰쓰기 모달(#58)이 쓰고 있어 건드리지 않고, 리뷰 카드용으로 `info-item.tsx`를 새로 뺐습니다. 값 스타일은 호출부가 클래스로 넘깁니다.

**② `disabled`는 별도 레이아웃이 아니었습니다**

피그마에 `sort=default` / `sort=disabled` 변형이 있어 6가지처럼 보이는데, 실제로는 **버튼 색만** `#D9D9D9`로 바뀝니다. 기존 `Button`의 `disabled:bg-gray-300`이 같은 값이라 `disabled` prop 하나로 처리했습니다.

**③ 모달 연결은 하지 않았습니다**

`작성 가능한 리뷰`의 "리뷰 작성하기" 버튼은 `onWriteClick` prop만 노출했습니다. 다른 카드(`onSendEstimate`, `onDetailClick`)와 같은 방식이고, 모달을 여는 건 페이지 책임이라고 봤습니다.

치호님 Modal(#58)이 머지되면 페이지 작업에서 연결하면 됩니다.

### 구분선 렌더링 통일 (추가)

피그마 구분선은 **높이 0인 벡터**라 레이아웃에 잡히지 않는데, `<hr>`의 `border-top: 1px`은 높이를 차지합니다. 내가 작성한 리뷰 sm 카드가 **412px**로 피그마(410)보다 2px 컸습니다.

카드 테두리를 `inset` 그림자로 바꾼 것과 같은 방식으로 `<hr>`도 전환했습니다.

```diff
- <hr className="border-line-100 w-full border-t" />
+ <hr className="h-0 w-full border-0 shadow-[0_0_0_0.5px_var(--color-line-100)]" />
```

**모달 3곳도 함께 수정했습니다** (`review-write-modal` 2곳, `quote-action-modal` 1곳). 카드와 모달이 나란히 쓰이는데 구분선 처리가 다르면 어긋나서요. @MunChiho

실측: 카드 높이 412 → **410**, 구분선은 `#f2f2f2` 0.5px로 그대로 보입니다.

## 📋 완료 체크리스트

- [x] 브랜치 방향(To dev)을 올바르게 설정했나요?
- [x] 무관한 파일이나 테스트용 코드가 커밋에 포함되지 않았나요?
- [x] (`npm run dev`) 시 에러가 발생하지 않나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 일반 리뷰, 내가 작성한 리뷰, 작성 가능한 리뷰를 확인할 수 있는 카드 목록 페이지를 추가했습니다.
  * 리뷰 카드의 다양한 크기와 상태를 지원하며, 리뷰 작성 가능 여부와 대상 지정 상태를 표시합니다.
  * 별점, 작성자 정보, 리뷰 내용, 이동 정보, 견적 금액 및 작성일을 카드에서 확인할 수 있습니다.
  * 프로필 이미지와 이름 표시 크기를 화면 구성에 맞게 개선했습니다.
* **스타일 개선**
  * 리뷰 카드와 구분선의 테두리 및 간격 표시를 일관되게 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->