### PR TITLE
feat: 공통 컴포넌트 ModalButton 작업

### DIFF
--- a/src/app/(main)/component-modal-button/page.tsx
+++ b/src/app/(main)/component-modal-button/page.tsx
@@ -1,0 +1,32 @@
+import Button from "@/component/common/button";
+import ModalButton from "@/component/common/modal-button";
+
+export default function ComponentModalButtonPage() {
+  return (
+    <div className="mx-auto flex max-w-md flex-col gap-8 p-10">
+      <section className="flex flex-col gap-3">
+        <h2 className="text-14 font-semibold text-gray-500">
+          Button size=&quot;md&quot; (60px) vs ModalButton (64px) — solid
+        </h2>
+        <Button size="md">기존 Button md</Button>
+        <ModalButton>ModalButton</ModalButton>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-14 font-semibold text-gray-500">outlined</h2>
+        <Button variant="outlined" size="md">
+          기존 Button md
+        </Button>
+        <ModalButton variant="outlined">ModalButton</ModalButton>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-14 font-semibold text-gray-500">disabled</h2>
+        <Button size="md" disabled>
+          기존 Button md
+        </Button>
+        <ModalButton disabled>ModalButton</ModalButton>
+      </section>
+    </div>
+  );
+}

--- a/src/component/common/modal-button.tsx
+++ b/src/component/common/modal-button.tsx
@@ -1,0 +1,37 @@
+import clsx from "clsx";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+type ModalButtonVariant = "solid" | "outlined";
+
+interface ModalButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ModalButtonVariant;
+  icon?: ReactNode;
+  children: ReactNode;
+}
+
+// 모달 전용 버튼 — md 높이만 64px (Button.tsx의 md는 60px, 모달 밖에서 쓰는 값과 달라 별도 컴포넌트로 분리)
+export default function ModalButton({
+  variant = "solid",
+  icon,
+  children,
+  className,
+  type = "button",
+  ...props
+}: ModalButtonProps) {
+  return (
+    <button
+      type={type}
+      className={clsx(
+        "text-18 flex h-16 w-full items-center justify-center gap-2 rounded-2xl px-4 font-semibold transition-colors",
+        variant === "solid"
+          ? "bg-orange-400 text-white not-disabled:hover:bg-orange-500 disabled:cursor-not-allowed disabled:bg-gray-300"
+          : "border border-orange-400 bg-gray-50 text-orange-400 shadow-[4px_4px_10px_0px_rgba(195,217,242,0.2)] not-disabled:hover:bg-orange-100 disabled:cursor-not-allowed disabled:border-gray-400 disabled:text-gray-500",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {icon}
+    </button>
+  );
+}


### PR DESCRIPTION
## 📌 개요

- 모달 내부에서 사용하는 버튼의 md 사이즈 높이가 기존 공통 Button(60px)과 다르게 64px이어야 해서, 모달 전용 ModalButton 컴포넌트를 새로 추가했습니다.

## 🔢 Linked Issue

- close #65 

## 🛠️ 주요 변경 사항

- [x] src/component/common/modal-button.tsx 추가 — size prop 없이 높이 64px 고정, variant(solid/outlined) 스타일은 기존 Button과 동일하게 재사용
- [x] 기존 Button 컴포넌트는 변경하지 않아 다른 화면(폼, 랜딩 CTA 등)의 md(60px) 동작에 영향 없음
- [x] src/app/(main)/component-modal-button/page.tsx 추가 — 기존 Button md(60px)와 ModalButton(64px)을 solid/outlined/disabled로 나란히 비교하는 프리뷰 페이지

## 📸 스크린샷 (선택)

## 🧪 테스트 결과 & 리뷰 요청 사항

- 테스트 페이지 component-modal-button 확인해 보시면 될 것 같습니다!
- npm run lint 통과 확인

## 📋 완료 체크리스트

- [x] 브랜치 방향(To dev)을 올바르게 설정했나요?
- [x] 무관한 파일이나 테스트용 코드가 커밋에 포함되지 않았나요?
- [x] (`npm run dev`) 시 에러가 발생하지 않나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 모달 화면에 최적화된 전체 너비 버튼을 추가했습니다.
  * Solid 및 Outlined 스타일과 선택적 아이콘 표시를 지원합니다.
  * 일반 버튼과 모달 버튼의 Solid, Outlined, Disabled 상태를 한눈에 비교할 수 있는 컴포넌트 안내 페이지를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->